### PR TITLE
Allow PHPUnit_Framework_TestSuite subclasses.

### DIFF
--- a/classes/phing/tasks/ext/phpunit/BatchTest.php
+++ b/classes/phing/tasks/ext/phpunit/BatchTest.php
@@ -199,7 +199,11 @@ class BatchTest
         
         foreach ($this->elements() as $test)
         {
-            $testClass = new ReflectionClass($test);
+            $testClass = new $test();
+            if (!($testClass instanceof PHPUnit_Framework_TestSuite))
+            {
+              $testClass = new ReflectionClass($test);
+            }
             
             $suite->addTestSuite($testClass);
         }
@@ -214,7 +218,12 @@ class BatchTest
     public function addToTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
         foreach ($this->elements() as $element) {
-            $suite->addTestSuite(new ReflectionClass($element));
+            $testClass = new $element();
+            if (!($testClass instanceof PHPUnit_Framework_TestSuite))
+            {
+                $testClass = new ReflectionClass($element);
+            }
+            $suite->addTestSuite($testClass);
         }
     }
     


### PR DESCRIPTION
PHPUnit expects PHPUnit_Framework_TestSuite subclasses to be added to an
existing test suite as real objects rather than as ReflectionClass
wrappers. This small change BatchTest checks the type of each test
before passing it on to PHPUnit and skips the reflection wrapper if the
class is of the correct type.

We use this for runtime instantiation of TestCase instances configured by some external source such as a yaml file.
