### PR TITLE
Remove deprecated split() usage.

### DIFF
--- a/classes/phing/tasks/ext/coverage/CoverageReportTask.php
+++ b/classes/phing/tasks/ext/coverage/CoverageReportTask.php
@@ -238,7 +238,7 @@ class CoverageReportTask extends Task
 
             $html = $geshi->parse_code();
 
-            $lines = split("<li>|</li>", $html);
+            $lines = preg_split("#</?li>#", $html);
 
             // skip first and last line
             array_pop($lines);

--- a/classes/phing/tasks/ext/phk/PhkPackageTask.php
+++ b/classes/phing/tasks/ext/phk/PhkPackageTask.php
@@ -224,7 +224,7 @@ class PhkPackageTask extends Task
          * Print with Phing log...
          */
         $output = trim(ob_get_clean());
-        $output = split("\n", $output);
+        $output = explode("\n", $output);
         foreach ($output as $line) {
             /*
              * Delete all '--- *' lines. Bluh!


### PR DESCRIPTION
PHP 5.3 has deprecated the split() function. Depending on how your PHP
5.3 runtime is configured the usage of this function may now emit
E_DEPRECATED notices which can lead to false build failures.

Use preg_split() or explode() instead.
