### PR TITLE
Guard against undefined XSL_SECPREF_WRITE_FILE.

### DIFF
--- a/classes/phing/tasks/ext/coverage/CoverageReportTransformer.php
+++ b/classes/phing/tasks/ext/coverage/CoverageReportTransformer.php
@@ -107,13 +107,16 @@ class CoverageReportTransformer
         $xsl->load($xslfile->getAbsolutePath());
 
         $proc = new XSLTProcessor();
-        if (version_compare(PHP_VERSION,'5.4',"<"))
+        if (defined('XSL_SECPREF_WRITE_FILE'))
         {
-            ini_set("xsl.security_prefs", XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
-        }
-        else
-        {
-            $proc->setSecurityPrefs(XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            if (version_compare(PHP_VERSION,'5.4',"<"))
+            {
+                ini_set("xsl.security_prefs", XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            }
+            else
+            {
+                $proc->setSecurityPrefs(XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            }
         }
         
         $proc->importStyleSheet($xsl);

--- a/classes/phing/tasks/ext/phpunit/PHPUnitReportTask.php
+++ b/classes/phing/tasks/ext/phpunit/PHPUnitReportTask.php
@@ -149,13 +149,16 @@ class PHPUnitReportTask extends Task
         $xsl->load($xslfile->getAbsolutePath());
 
         $proc = new XSLTProcessor();
-        if (version_compare(PHP_VERSION,'5.4',"<"))
+        if (defined('XSL_SECPREF_WRITE_FILE'))
         {
-            ini_set("xsl.security_prefs", XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
-        }
-        else
-        {
-            $proc->setSecurityPrefs(XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            if (version_compare(PHP_VERSION,'5.4',"<"))
+            {
+                ini_set("xsl.security_prefs", XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            }
+            else
+            {
+                $proc->setSecurityPrefs(XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            }
         }
         
         $proc->importStyleSheet($xsl);


### PR DESCRIPTION
Related to #800 at phing.info. Usage of constant XSL_SECPREF_WRITE_FILE
in older versions of php produces an undefined constant warning.
Depending on php runtime configuration this can lead to a fatal error as
some php environments will install a error to exception routine.
