### PR TITLE
Fixing missing parser errors for DocBlox output

### DIFF
--- a/classes/phing/tasks/ext/docblox/DocBloxTask.php
+++ b/classes/phing/tasks/ext/docblox/DocBloxTask.php
@@ -146,6 +146,11 @@ class DocBloxTask extends Task
     private function parseFiles()
     {
         $parser = new DocBlox_Parser();
+
+        //Only initialize the dispatcher when not already done
+        if (is_null(DocBlox_Parser_Abstract::$event_dispatcher)) {
+            DocBlox_Parser_Abstract::$event_dispatcher = new sfEventDispatcher();
+        }
         DocBlox_Parser_Abstract::$event_dispatcher = new sfEventDispatcher();
         $parser->setTitle($this->title);
         


### PR DESCRIPTION
First try ever at git so I hope this all will work :) As explained to mrook, the parser errors are not shown in the DocBlox output.
