### PR TITLE
DocBlox task now shows parser errors again

### DIFF
--- a/classes/phing/tasks/ext/docblox/DocBloxTask.php
+++ b/classes/phing/tasks/ext/docblox/DocBloxTask.php
@@ -146,7 +146,11 @@ class DocBloxTask extends Task
     private function parseFiles()
     {
         $parser = new DocBlox_Parser();
-        DocBlox_Parser_Abstract::$event_dispatcher = new sfEventDispatcher();
+        
+        //Only initialize the dispatcher when not already done
+        if (is_null(DocBlox_Parser_Abstract::$event_dispatcher)) {
+        	DocBlox_Parser_Abstract::$event_dispatcher = new sfEventDispatcher();
+        }
         $parser->setTitle($this->title);
         
         $paths = array();


### PR DESCRIPTION
New try with the pull request :) As stated before, due to overwriting the dispatcher with a new one there are no parsing errors in the DocBlox output.
