### PR TITLE
Added simple GitCommitTask

### DIFF
--- a/classes/phing/tasks/ext/git/GitCommitTask.php
+++ b/classes/phing/tasks/ext/git/GitCommitTask.php
@@ -48,6 +48,10 @@ class GitCommitTask extends GitBaseTask
      */
     public function main()
     {
+        if (null === $this->getRepository()) {
+            throw new BuildException('"repository" is required parameter');
+        }
+
         if (null === $this->getTargetPath()) {
             throw new BuildException('"targetPath" is required parameter');
         }


### PR DESCRIPTION
For a particular packaging workflow we wanted to be able to create new packages, commit them and push them to a remote repo. So, I added the GitCommit task. It is simple and would not be flexible enough for every use case but covers most of the ones we might need. 
