### PR TITLE
Adding proper role mapping for PearPackage2Task.

### DIFF
--- a/classes/phing/tasks/ext/PearPackage2Task.php
+++ b/classes/phing/tasks/ext/PearPackage2Task.php
@@ -236,6 +236,12 @@ class PearPackage2Task extends PearPackageTask {
                     }
                     break;
 
+				case 'role':
+					foreach ($map->getValue() as $role) {
+						$this->pkg->addRole($role['extension'], $role['role']);
+					}
+					break;
+
                 default:
                     $newmaps[] = $map;
             }


### PR DESCRIPTION
I noticed that the role mapping for PearPackage2Task didn't work correctly. This patch fixes that.
