### PR TITLE
Fix incorrect parsing of "create rule" statements with semicolons in PGSQL splitter.

### DIFF
--- a/classes/phing/tasks/ext/pdo/PgsqlPDOQuerySplitter.php
+++ b/classes/phing/tasks/ext/pdo/PgsqlPDOQuerySplitter.php
@@ -29,7 +29,7 @@ require_once 'phing/tasks/ext/pdo/PDOQuerySplitter.php';
  * Unlike DefaultPDOQuerySplitter this uses a lexer instead of regular
  * expressions. This allows handling complex constructs like C-style comments
  * (including nested ones) and dollar-quoted strings.
- * 
+ *
  * @author  Alexey Borzov <avb@php.net>
  * @package phing.tasks.ext.pdo
  * @version $Id$
@@ -110,7 +110,7 @@ class PgsqlPDOQuerySplitter extends PDOQuerySplitter
     * Bactracks one symbol on the input
     *
     * NB: we don't need ungetc() at the start of the line, so this case is
-    * not handled. 
+    * not handled.
     */
     public function ungetc()
     {
@@ -152,11 +152,12 @@ class PgsqlPDOQuerySplitter extends PDOQuerySplitter
             }
         }
     }
-    
+
     public function nextQuery()
     {
-        $sql       = '';
-        $delimiter = $this->parent->getDelimiter();
+        $sql        = '';
+        $delimiter  = $this->parent->getDelimiter();
+        $openParens = 0;
 
         while (false !== ($ch = $this->getc())) {
             switch ($this->state) {
@@ -191,8 +192,19 @@ class PgsqlPDOQuerySplitter extends PDOQuerySplitter
                         continue 3;
                     }
                     break;
+                case '(':
+                    $openParens++;
+                    break;
+                case ')':
+                    $openParens--;
+                    break;
                 // technically we can use e.g. psql's \g command as delimiter
                 case $delimiter[0]:
+                    // special case to allow "create rule" statements
+                    // http://www.postgresql.org/docs/current/interactive/sql-createrule.html
+                    if (';' == $delimiter && 0 < $openParens) {
+                        break;
+                    }
                     $hasQuery = true;
                     for ($i = 1; $i < strlen($delimiter); $i++) {
                         if ($delimiter[$i] != $this->getc()) {

--- a/test/classes/phing/tasks/ext/PDO/PDODelimitersTest.php
+++ b/test/classes/phing/tasks/ext/PDO/PDODelimitersTest.php
@@ -33,7 +33,7 @@ class PDODelimitersTest extends BuildFileTest
     protected $queries = array();
 
     protected $mockTask;
-    
+
     public function setUp()
     {
         $this->configureProject(PHING_TEST_BASE . "/etc/tasks/ext/pdo/empty.xml");
@@ -89,7 +89,7 @@ SQL
         foreach ($expected as &$query) {
             $query = str_replace(array("\n\n", "\r"), array("\n", ''), $query);
         }
-        
+
         $this->mockTask->setSrc(new PhingFile(PHING_TEST_BASE . "/etc/tasks/ext/pdo/delimiters-normal.sql"));
         $this->project->setProperty('bar.value', "some value");
         $this->project->executeTarget('test');
@@ -174,12 +174,16 @@ else
 \$_X$
     LANGUAGE plperl
 SQL
-, <<<SQL
-insert into foo (bar) 
-values ('some value')
-SQL
+, "insert into foo (bar) \nvalues ('some value')"
 , <<<SQL
 insert into foo (bar) values ($$ a dollar-quoted string containing a few quotes ' ", a \$placeholder$ and a semicolon;$$)
+SQL
+, <<<SQL
+create rule blah_insert
+as on insert to blah do instead (
+    insert into foo values (new.id, 'blah');
+    insert into bar values (new.id, 'blah-blah');
+)
 SQL
 , <<<SQL
 insert into dump (message) values ('I am a statement not ending with a delimiter')
@@ -193,7 +197,7 @@ SQL
         $this->mockTask->setUrl('pgsql:host=localhost;dbname=phing');
         $this->project->setProperty('bar.value', "some value");
         $this->project->executeTarget('test');
-        
+
         $this->assertEquals($expected, $this->queries);
     }
 }

--- a/test/etc/tasks/ext/pdo/delimiters-pgsql.sql
+++ b/test/etc/tasks/ext/pdo/delimiters-pgsql.sql
@@ -45,8 +45,16 @@ else
 $_X$
     LANGUAGE plperl;
 
-insert into foo (bar) -- I can be safely ignored as PostgreSQL does not have hints 
+insert into foo (bar) -- I can be safely ignored as PostgreSQL does not have hints
 values ('${bar.value}');
 insert into foo (bar) values ($$ a dollar-quoted string containing a few quotes ' ", a $placeholder$ and a semicolon;$$);
+
+-- "create rule" statement may contain semicolons inside parentheses
+create rule blah_insert
+as on insert to blah do instead (
+    insert into foo values (new.id, 'blah');
+    insert into bar values (new.id, 'blah-blah');
+);
+
 
 insert into dump (message) values ('I am a statement not ending with a delimiter')


### PR DESCRIPTION
This patch was written by Alexey Borzov, he asked me to make a pull request.

See commit 4f3cd81714db1d247aa94918522f20d3e5dbc1e3.
