### PR TITLE
Added composer.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/full
 build/pear
 test/reports
 docs/api/docs
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "phing/phing",
+    "description": "PHing Is Not GNU make; it's a PHP project build system or build tool based on Apache Ant.",
+    "keywords": ["build", "tool", "task"],
+    "homepage": "http://www.phing.info/",
+    "license": "LGPL3",
+    "authors": [
+        {
+            "name": "Michiel Rook",
+            "email": "mrook@php.net"
+        },
+        {
+            "name": "Phing Community",
+            "homepage": "http://www.phing.info/trac/wiki/Development/Contributors"
+    ],
+    "require": {
+        "php": ">=5.2.0"
+    },
+    "autoload": {
+        "classmap": ["classes/phing/"]
+    }
+}


### PR DESCRIPTION
Heya,

Here is a Pull Request to add a `composer.json` file. There is no side effect, it's just a simple file which can be really useful for a lot of people. For instance, I'm the lead developer of the [Propel ORM](http://www.propelorm.org) project, and we use Phing a lot. We decided to distribute our new releases using [Composer](http://getcomposer.org), and we would like to require Phing through Composer.

So, [Composer](http://getcomposer.org) is a new dependency manager for PHP. It allows you to specify dependencies on a per-project basis. It takes lots of inspiration from NPM and ruby's bundler.

All you need to support composer is a `composer.json` file. In order to allow easy installation, the repository needs to be added to [packagist](http://packagist.org/), which is the standard repository for composer. Packagist will fetch all the versions from your github repository tags.

Once it has been added, adding **Phing** to a project will be as easy as creating this `composer.json` file in the project's directory:

```
{
    "require": {
        "phing/phing": "*"
    }
}
```

And running this command:

```
$ php composer.phar install
```

Note: Packagist will re-crawl github for new versions all the time. After submitting it once, you don't have to do anything else.

Check out the following information on composer and packagist:
- [getcomposer.org](http://getcomposer.org/)
- [packagist.org](http://packagist.org)
- [composer on GitHub](https://github.com/composer/composer)
- #composer on irc.freenode.net

Cheers!
William
