### PR TITLE
Fix use of undefined constant

### DIFF
--- a/classes/phing/tasks/ext/svn/SvnBaseTask.php
+++ b/classes/phing/tasks/ext/svn/SvnBaseTask.php
@@ -49,7 +49,7 @@ abstract class SvnBaseTask extends Task
 
     private $toDir = "";
     
-    protected $fetchMode = VERSIONCONTROL_SVN_FETCHMODE_ASSOC;
+    protected $fetchMode;
 
     /**
      * Initialize Task.
@@ -59,6 +59,7 @@ abstract class SvnBaseTask extends Task
      */
     function init() {
         include_once 'VersionControl/SVN.php';
+        $this->fetchMode = VERSIONCONTROL_SVN_FETCHMODE_ASSOC;
         if (!class_exists('VersionControl_SVN')) {
             throw new Exception("The SVN tasks depend on PEAR VersionControl_SVN package being installed.");
         }


### PR DESCRIPTION
This patch fixes an error I encountered. It was caused by use of constant before it was defined (ie. before it's file was included).

The error was (in verbose mode):
[PHP Error] Use of undefined constant VERSIONCONTROL_SVN_FETCHMODE_ASSOC - assumed 'VERSIONCONTROL_SVN_FETCHMODE_ASSOC' [line 676 of /home/radek/sources/php-deployment/vendor/phing/phing/classes/phing/Project.php]

This made VersionControl_SVN_List task fail to parse the output in parseOutput. Tested with PHP 5.3.10.
