### PR TITLE
Corrected paths reference for finding resource path

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -1074,7 +1074,7 @@ class Phing {
 
         if (self::$importPaths === null) {
             $paths = get_include_path();
-            self::$importPaths = explode(PATH_SEPARATOR, ini_get("include_path"));
+            self::$importPaths = explode(PATH_SEPARATOR, $paths);
         }
 
         $path = str_replace('\\', DIRECTORY_SEPARATOR, $path);


### PR DESCRIPTION
I guess there are 2 possible changes here:
1. Remove the get_include_path line (as it's currently not used)
2. The solution in the PR - just using get_include_path instead of getting the ini value

I prefer 2. because it will include any runtime modifications to the include path
