### PR TITLE
Concatenate property lines ending with backslash

### DIFF
--- a/classes/phing/system/util/Properties.php
+++ b/classes/phing/system/util/Properties.php
@@ -91,7 +91,16 @@ class Properties {
         if (($lines = @file($filePath)) === false) {
             throw new IOException("Unable to parse contents of $filePath");
         }
-        
+
+        // concatenate lines ending with backslash
+        $linesCount = count($lines);
+        for($i = 0; $i < $linesCount; $i++) {
+            if (substr($lines[$i], -2, 1) === '\\') {
+                $lines[$i + 1] = substr($lines[$i], 0, -2) . ltrim($lines[$i + 1]);
+                $lines[$i] = '';
+            }
+        }
+
         $this->properties = array();
         $sec_name = "";
         


### PR DESCRIPTION
Hi,
we are migrating from Ant to Phing and had problems with not working multiline properties:

<pre>
property = value1 \
                value2 \
                value3
</pre>


This patch enables them. The property value is concatenated from lines as expected so the code above is equal to this one:

<pre>
property = value1 value2 value3
</pre>
