### PR TITLE
S3Put Content Type support

### DIFF
--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -84,6 +84,35 @@ class S3PutTask extends Service_Amazon_S3
 	 * @access protected
 	 */
 	protected $_acl = 'private';
+	
+	/**
+	 * File content type
+	 * Use this to set the content type of your static files
+	 * Set contentType to "auto" if you want to autodetect the content type based on the source file extension
+	 *
+	 * (default value: 'binary/octet-stream')
+	 *
+	 * @var string
+	 * @access protected
+	 */
+	protected $_contentType = 'binary/octet-stream';
+	
+	/**
+	 * Extension content type mapper
+	 *
+	 * @var array
+	 * @access protected
+	 */
+	protected $_extensionContentTypeMapper = array(
+		'js'	=> 'application/x-javascript',
+		'css'	=> 'text/css',
+		'html'	=> 'text/html',
+		'gif'	=> 'image/gif',
+		'png'	=> 'image/png',
+		'jpg'	=> 'image/jpeg',
+		'jpeg'	=> 'image/jpeg',
+		'txt'	=> 'text/plain'
+	);
     
     public function setSource($source)
     {
@@ -151,6 +180,25 @@ class S3PutTask extends Service_Amazon_S3
 	public function getAcl()
 	{
 		return $this->_acl;
+	}
+	
+	public function setContentType($contentType) 
+	{
+		$this->_contentType = $contentType;
+	}
+
+	public function getContentType()
+	{
+		if($this->_contentType === 'auto') {
+			$ext = strtolower(substr(strrchr($this->getSource(), '.'), 1));
+			if(isset($this->_extensionContentTypeMapper[$ext])) {
+				return $this->_extensionContentTypeMapper[$ext];
+			} else {
+				return 'binary/octet-stream';
+			}
+		} else {
+			return $this->_contentType;
+		}
 	}
 
 	public function setCreateBuckets($createBuckets)
@@ -260,6 +308,7 @@ class S3PutTask extends Service_Amazon_S3
 		$object = $this->getObjectInstance($object);
 		$object->data = $data;
 		$object->acl = $this->getAcl();
+		$object->contentType = $this->getContentType();
 		$object->save();
 		
 		if(!$this->isObjectAvailable($object->key)) {


### PR DESCRIPTION
By default all putted S3 object are given the content type "binary/octet-stream".
This can give problems for CSS/JS and maybe some other files types when loading them in your application.

With this extension you can now use the property "contentType" to set the content type of the file you put.
You can also set the contentType property to "auto" for auto detecting the content type based on the source file extension.
