### PR TITLE
text encoding for emails.

### DIFF
--- a/classes/phing/tasks/ext/MailTask.php
+++ b/classes/phing/tasks/ext/MailTask.php
@@ -56,7 +56,7 @@ class MailTask extends Task
                 throw new BuildException('Need the PEAR Mail_mime package to send attachments');
             }
             
-            $mime = new Mail_mime();
+            $mime = new Mail_mime(array('text_charset' => 'UTF-8'));
             $hdrs = array(
             	'From'    => $this->from,
             	'Subject' => $this->subject


### PR DESCRIPTION
A phing script is often encoded as UTF-8. With this patch the email looks a little bit better if this is the case.
The default test encoding in Mail_mime is iso-8859-1, but xml files are often written as utf-8.

Please understand this as a feature request and not as a complete fix. I think, the best solution would be possible, if the task could know, which encoding is used for the phing file.
