### PR TITLE
DbDeploy should not assume a SQL file missing --@Undo is only a rollback.

### DIFF
--- a/classes/phing/tasks/ext/dbdeploy/DbDeployTask.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbDeployTask.php
@@ -251,6 +251,8 @@ class DbDeployTask extends Task
                 $split = strpos($contents, '-- //@UNDO');
                 if ($split === false)
                     $split = strpos($contents, '--//@UNDO');
+                if ($split === false)
+                    $split = strlen($contents);
 
                 if ($undo) {
                     $sql .= substr($contents, $split + 10) . "\n";


### PR DESCRIPTION
Currently, if you omit or forget the --@undo in an SQL migration, the split position fill default to false, which in turn will become 0. This will lead to the behavior, that the whole SQL file will be copied into the Undo file, while the update file will stay empty.

This Tiny patch checks if the undo tag was not found, and will set the split location to the end of the file, so that the entife sql file will be copied into the update SQL.
