### PR TITLE
added classes path to include_path in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,6 @@
     "autoload": {
         "classmap": ["classes/phing/"]
     },
+    "include-path": ["classes"],
     "bin": ["bin/phing"]
 }


### PR DESCRIPTION
this should avoid issues with libraries that require phing in include_path like propel
