### PR TITLE
ExecTask: Do not change command attribute

### DIFF
--- a/classes/phing/tasks/system/ExecTask.php
+++ b/classes/phing/tasks/system/ExecTask.php
@@ -35,7 +35,13 @@ class ExecTask extends Task
 {
 
     /**
-     * Command to execute.
+     * Command to be executed
+     * @var string
+     */
+    protected $realCommand;
+
+    /**
+     * Given command
      * @var string
      */
     protected $command;
@@ -82,7 +88,7 @@ class ExecTask extends Task
      * @var boolean
      */
     protected $logOutput = false;
-    
+
     /**
      * Logging level for status messages
      * @var integer
@@ -210,12 +216,12 @@ class ExecTask extends Task
                 'ExecTask: Please provide "command" OR "executable"'
             );
         } else if ($this->command === null) {
-            $this->command = Commandline::toString($this->commandline->getCommandline(), $this->escape);
+            $this->realCommand = Commandline::toString($this->commandline->getCommandline(), $this->escape);
         } else if ($this->commandline->getExecutable() === null) {
             //we need to escape the command only if it's specified directly
             // commandline takes care of "executable" already
             if ($this->escape == true) {
-                $this->command = escapeshellcmd($this->command);
+                $this->realCommand = escapeshellcmd($this->command);
             }
         } else {
             throw new BuildException(
@@ -224,7 +230,7 @@ class ExecTask extends Task
         }
 
         if ($this->error !== null) {
-            $this->command .= ' 2> ' . $this->error->getPath();
+            $this->realCommand .= ' 2> ' . $this->error->getPath();
             $this->log(
                 "Writing error output to: " . $this->error->getPath(),
                 $this->logLevel
@@ -232,13 +238,13 @@ class ExecTask extends Task
         }
 
         if ($this->output !== null) {
-            $this->command .= ' 1> ' . $this->output->getPath();
+            $this->realCommand .= ' 1> ' . $this->output->getPath();
             $this->log(
                 "Writing standard output to: " . $this->output->getPath(),
                 $this->logLevel
             );
         } elseif ($this->spawn) {
-            $this->command .= ' 1>/dev/null';
+            $this->realCommand .= ' 1>/dev/null';
             $this->log("Sending output to /dev/null", $this->logLevel);
         }
 
@@ -247,12 +253,12 @@ class ExecTask extends Task
         // it to screen below.
 
         if ($this->output === null && $this->error === null) {
-            $this->command .= ' 2>&1';
+            $this->realCommand .= ' 2>&1';
         }
 
         // we ignore the spawn boolean for windows
         if ($this->spawn) {
-            $this->command .= ' &';
+            $this->realCommand .= ' &';
         }
     }
 
@@ -263,15 +269,15 @@ class ExecTask extends Task
      */
     protected function executeCommand()
     {
-        $this->log("Executing command: " . $this->command, $this->logLevel);
+        $this->log("Executing command: " . $this->realCommand, $this->logLevel);
 
         $output = array();
         $return = null;
-        
+
         if ($this->passthru) {
-            passthru($this->command, $return);
+            passthru($this->realCommand, $return);
         } else {
-            exec($this->command, $output, $return);
+            exec($this->realCommand, $output, $return);
         }
 
         return array($return, $output);
@@ -446,7 +452,7 @@ class ExecTask extends Task
     {
         $this->checkreturn = (bool) $checkreturn;
     }
-    
+
     /**
      * The name of property to set to return value from exec() call.
      *
@@ -470,7 +476,7 @@ class ExecTask extends Task
     {
         $this->outputProperty = $prop;
     }
-    
+
     /**
      * Set level of log messages generated (default = verbose)
      *


### PR DESCRIPTION
ExecTask cannot be executed more than once (which we use), because it changes content of attribute command. If you use executable attribute, you will get error 'Either use "command" OR "executable' in the second call, because then both command and executable attributes are set.

This patch adds attribute realCommand which is used instead of original command. Attribute command is used only to store input from the user.
