### PR TITLE
Added attribute logoutput to property task

### DIFF
--- a/classes/phing/tasks/system/PropertyTask.php
+++ b/classes/phing/tasks/system/PropertyTask.php
@@ -57,6 +57,9 @@ class PropertyTask extends Task {
      */
     protected $filterChains  = array();
 
+    /** Whether to log messages as INFO or VERBOSE  */
+    protected $logOutput = true;
+
     /**
      * Sets a the name of current property component
      */
@@ -209,6 +212,14 @@ class PropertyTask extends Task {
         return $this->filterChains[$num-1];
     }  
 
+    function setLogoutput($logOutput) {
+        $this->logOutput = (bool) $logOutput;
+    }
+
+    function getLogoutput() {
+        return $this->logOutput;
+    }
+
     /**
      * set the property in the project to the value.
      * if the task was give a file or env attribute
@@ -320,7 +331,7 @@ class PropertyTask extends Task {
      */
     protected function loadFile(PhingFile $file) {
         $props = new Properties();
-        $this->log("Loading ". $file->getAbsolutePath(), Project::MSG_INFO);
+        $this->log("Loading ". $file->getAbsolutePath(), $this->logOutput ? Project::MSG_INFO : Project::MSG_VERBOSE);
         try { // try to load file
             if ($file->exists()) {
                 $props->load($file);

--- a/docs/docbook5/en/source/appendixes/coretasks.xml
+++ b/docs/docbook5/en/source/appendixes/coretasks.xml
@@ -2584,6 +2584,14 @@
                         <entry>n/a</entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>logoutput</literal></entry>
+                        <entry><literal role="type">Boolean</literal></entry>
+                        <entry>Whether to log returned output as MSG_INFO instead of
+                            MSG_VERBOSE.</entry>
+                        <entry><literal>true</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>


### PR DESCRIPTION
Hi,
here is a little patch which adds possibility to set logging of loading property files as verbose instead of info.

Cheers
