### PR TITLE
Phing extened .properties file

### DIFF
--- a/classes/phing/tasks/ext/properties/PropertiesFile.php
+++ b/classes/phing/tasks/ext/properties/PropertiesFile.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Require base Properties class to extend it 
+ */
+include_once 'phing/system/util/Properties.php';
+/**
+ * PropertiesFile class supports a recursive properties load
+ * 
+ * @package phing.tasks.ext.properties
+ * @author Shaked (phing@shakedos.com)
+ * @version $Id$
+ */
+class PropertiesFile extends Properties {  
+	/**
+	 * @var const - decides how to retreive the extended environment string 
+	 */
+	const EXTENDS_REGEX = '\{\sextends(.*)\}'; 
+	/**
+	 * (non-PHPdoc)
+	 * @see Properties::parse()
+	 */
+    protected function parse($filePath) {
+
+        // load() already made sure that file is readable                
+        // but we'll double check that when reading the file into 
+        // an array
+        
+        if (($lines = @file($filePath)) === false) {
+            throw new IOException("Unable to parse contents of $filePath");
+        }
+         
+        $sec_name = ""; 
+        
+        // check extends 
+        $extendedFilename = $this->getExtendedFilename($lines[0]);   
+        if ($extendedFilename){
+        	//get path create file and load again 
+        	$newFileName = substr($filePath,0,strrpos($filePath,'/')) . '/' .$extendedFilename . '.properties';
+        	$file = new PhingFile($newFileName); 
+        	//load before so we can override later 
+        	$this->load($file);
+        }   
+        
+        foreach($lines as $line) {
+            // strip comments and leading/trailing spaces
+            $line = trim(preg_replace("/\s+[;#]\s.+$/", "", $line));
+            
+            if (empty($line) || $line[0] == ';' || $line[0] == '#' || $line[0] == '{') { // { should be skipped
+                continue;
+            }
+                
+            $pos = strpos($line, '=');
+            $property = trim(substr($line, 0, $pos));
+            $value = trim(substr($line, $pos + 1));    
+            $propertyValue = $this->inVal($value);        
+            //set private properties variable   
+            $this->setProperty($property,$propertyValue);
+        } // for each line 
+    }
+    /** 
+     * Get the the name of the extended file 
+     * @param string $line - the first line
+     * @return string|false 
+     */
+    protected function getExtendedFilename($line){
+    	if (preg_match('#'.self::EXTENDS_REGEX.'#', $line,$matches)){
+    		return trim($matches[1]); 
+    	}
+    	return false; 
+    } 
+}

--- a/classes/phing/tasks/ext/properties/PropertiesFileTask.php
+++ b/classes/phing/tasks/ext/properties/PropertiesFileTask.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Require PropertyTask to extend it 
+ */
+include_once 'phing/tasks/system/PropertyTask.php';
+/**
+ * Use PropertiesFile instead of Properties class 
+ */
+include_once 'PropertiesFile.php';
+/**
+ * 
+ * PropertiesFileTask is a class which extends the behavior of PropertyTask 
+ * 	So when loading an .properties you would be able to extend it from other 
+ * 		.properties files as well
+ * @package phing.tasks.ext.properties
+ * @author Shaked (phing@shakedos.com)
+ * @version $Id$
+ */
+class PropertiesFileTask extends PropertyTask { 
+    /**
+     * load properties from a file.
+     * @param PhingFile $file - the file
+     * @throws BuildException
+     */
+    protected function loadFile(PhingFile $file) {
+        $props = new PropertiesFile();
+        $this->log("Loading ". $file->getAbsolutePath(), Project::MSG_INFO); 
+        try { // try to load file
+            if ($file->exists()) {
+                $props->load($file); 
+                $this->addProperties($props);
+            } else {
+                $this->log("Unable to find property file: ". $file->getAbsolutePath() ."... skipped", Project::MSG_WARN);
+            }
+        } catch (IOException $ioe) {
+            throw new BuildException("Could not load properties from file.", $ioe);
+        }
+    }
+    /**
+     * (non-PHPdoc)
+     * @see PropertyTask::main()
+     * @throws BuildException
+     */
+	 public function main() {
+	 	if (!$this->file){
+	 		throw new BuildException('File property is required'); 
+	 	}
+	 	parent::main(); 
+	 }
+} 


### PR DESCRIPTION
By using the follow phrase { extend ENV } (while ENV represents the extended .properties file name) at the top of the .properties file it is possible to extend\inherit .properties files and decouple configuration parameters 
