### PR TITLE
correct check for ssh2_connect failure in SshTask

### DIFF
--- a/classes/phing/tasks/ext/SshTask.php
+++ b/classes/phing/tasks/ext/SshTask.php
@@ -178,7 +178,7 @@ class SshTask extends Task {
         }
         
         $this->connection = ssh2_connect($this->host, $this->port);
-        if (is_null($this->connection)) {
+        if (!$this->connection) {
             throw new BuildException("Could not establish connection to " . $this->host . ":" . $this->port . "!");
         }
 


### PR DESCRIPTION
ssh2_connect returns false on failure instead of null.  current check for null lets failure past and false is passed to the ssh2_auth step.
