### PR TITLE
Add xsl.security_prefs manipulation to XsltFilter.

### DIFF
--- a/classes/phing/filters/XsltFilter.php
+++ b/classes/phing/filters/XsltFilter.php
@@ -261,6 +261,13 @@ class XsltFilter extends BaseParamFilterReader implements ChainableReader {
         
         $xslDom->loadxml($xsl);
         
+        if (defined('XSL_SECPREF_WRITE_FILE')) {
+            if (version_compare(PHP_VERSION,'5.4',"<")) {
+                ini_set("xsl.security_prefs", XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            } else {
+                $proc->setSecurityPrefs(XSL_SECPREF_WRITE_FILE | XSL_SECPREF_CREATE_DIRECTORY);
+            }
+        }
         $processor->importStylesheet($xslDom);
 
         // ignoring param "type" attrib, because


### PR DESCRIPTION
Adds check to enable necessary permissions for creating new files and
directories using XSLTProcessor if appropriate for php runtime.

For more details, see:
- http://www.phing.info/trac/ticket/938
- http://www.phing.info/trac/ticket/800
- https://bugs.php.net/bug.php?id=54446
