### PR TITLE
Copy task - PreservePermissions Attribute

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -30,6 +30,7 @@ Phing 2.x Development
   - Christian Weiske
   - Matthias Pigulla
   - Lineke Kerckhoffs-Willems <lineke@phpassionate.com>
+  - Utsav Handa <handautsav@hotmail.com>
 
   If you've done work on Phing and you are not listed here, please feel free
   to add yourself.

--- a/docs/docbook5/en/source/appendixes/coretasks.xml
+++ b/docs/docbook5/en/source/appendixes/coretasks.xml
@@ -610,6 +610,16 @@
 						<entry>No</entry>
 					</row>
 					<row>
+						<entry>preservemode or preservepermissions</entry>
+						<entry><literal role="type">Boolean</literal></entry>
+						<entry>If set to <literal>true</literal>, the new file (and directory) will have the same
+							permissions as the old one. The <literal>mode</literal> specified for directory creation
+                            will be ignored, if this is set to <literal>true</literal>.
+                        </entry>
+						<entry><literal>true</literal></entry>
+						<entry>No</entry>
+					</row>
+					<row>
 						<entry><literal>includeemptydirs</literal></entry>
 						<entry><literal role="type">Boolean</literal></entry>
 						<entry>If set to <literal>true</literal>, also empty directories are copied. </entry>


### PR DESCRIPTION
## CopyTask "preservePermissions" Attribute

CopyTask enables a file/directory copying to a new file or directory.

@Ticket
http://www.phing.info/trac/ticket/910

This pull request adds the support for the following attribute:
- preservePermissions (alias preserveMode)

The attribute default state is 'true', providing the file/directory permissions to
be synced on the target file/directory resources. If the attribute is turned off,
then the newly created target file/directory resources will be created according 
to the current umask information.

An additional functional adjustment has been done, where the target parent or 
empty directory creation was not using the 'mode' attribute value. 

The directory creation in the task has been adjusted to create the target directory
with source directory permissions when 'preservePermissions' is true, else the attribute
'mode' is being used.

The CopyTask documentation has been updated with the attribute information.

Thanks,
Utsav
