### PR TITLE
Fixed an issue with S3PutTask where the path was added to the filename

### DIFF
--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -294,7 +294,7 @@ class S3PutTask extends Service_Amazon_S3
 			$fromDir = $fs->getDir($this->getProject())->getAbsolutePath();
 			
 			foreach($objects as $object) {
-				$this->saveObject($object, file_get_contents($fromDir . DIRECTORY_SEPARATOR . $object));
+				$this->saveObject(basename($object), file_get_contents($fromDir . DIRECTORY_SEPARATOR . $object));
 			}
 			
 			return true;


### PR DESCRIPTION
Currently, when files are uploaded to an S3 bucket the original file names contain the full path as the name. 

A simple basename function call was added to the object variable containing the file name.
