### PR TITLE
PHP Error when using file parameter on available system task

### DIFF
--- a/classes/phing/tasks/system/AvailableTask.php
+++ b/classes/phing/tasks/system/AvailableTask.php
@@ -40,6 +40,9 @@ class AvailableTask extends Task {
     /** Value property should be set to. */
     private $value = "true";
 
+    /** File/directory to check existence */
+    private $file;
+
     /** Resource to check for */
     private $resource;
 


### PR DESCRIPTION
Hello,

While I've changed my phing build doc script on PHP_CompatInfo, and put the available system task, I found a PHP Error.

First try with : 

```
<available file="phing/tasks/ext/GrowlNotifyTask.php" property="file.exists" />
```

with -debug option I saw  

```
  +Task: available
    -calling setter AvailableTask::setResource()
    -calling setter AvailableTask::setProperty()
[PHP Error] Undefined property: AvailableTask::$file [line 111 of C:\UwAmp\bin\php\php-5.2.17\PEAR\phing\tasks\system\AvailableTask.php]
[PHP Error] Undefined property: AvailableTask::$file [line 119 of C:\UwAmp\bin\php\php-5.2.17\PEAR\phing\tasks\system\AvailableTask.php]
```

Then I changed to 

```
<available resource="phing/tasks/ext/GrowlNotifyTask.php" property="file.exists" />
```

And all goes fine. But to use the file parameter I propose this fix (pull request).

Hope it will help
Laurent
