### PR TITLE
Make exists() work on domain sockets (v2)

### DIFF
--- a/classes/phing/system/io/PhingFile.php
+++ b/classes/phing/system/io/PhingFile.php
@@ -445,15 +445,15 @@ class PhingFile {
      * @return boolean true if and only if the file denoted by this
      *                 abstract pathname exists; false otherwise
      */
-    function exists() {                
+    function exists() {
         clearstatcache();
-        
+
         if (is_link($this->path)) {
             return true;
-        } else if ($this->isFile()) {
-            return @file_exists($this->path) || is_link($this->path);
+        } else if ($this->isDirectory()) {
+            return true;
         } else {
-            return @is_dir($this->path);
+            return @file_exists($this->path) || is_link($this->path);
         }
     }
 


### PR DESCRIPTION
This is a reformatted version of #142 which contained a lot of whitespace changes (my Vim automatically strips trailing whitespace). Since @llaville already fixed he E_NOTICE fix I haven't included it in this PR.
