### PR TITLE
Fixing a small bug to set source when ContentType is used

### DIFF
--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -316,7 +316,7 @@ class S3PutTask extends Service_Amazon_S3
 		            } else {
 		                foreach ($objects as $object) {
 		                    $this->_source = $object;  	
-		                    $this->saveObject(str_replace('\\', '/', $object), file_get_contents($fromDir . DIRECTORY_SEPARATOR . $object));
+		                    $this->saveObject($object, file_get_contents($fromDir . DIRECTORY_SEPARATOR . $object));
 		                }
 		            }
 			


### PR DESCRIPTION
When a file set is made use with the S3Put task it throws a BuildException of `Source is not set`.

This is simply missing the setting of the source so that the content type can be determined.
