### PR TITLE
Avoiding paths becoming part of the filename for Windows users

### DIFF
--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -316,7 +316,7 @@ class S3PutTask extends Service_Amazon_S3
 		            } else {
 		                foreach ($objects as $object) {
 		                    $this->_source = $object;
-		                    $this->saveObject($object, file_get_contents($fromDir . DIRECTORY_SEPARATOR . $object));
+		                    $this->saveObject(str_replace('\\', '/', $object), file_get_contents($fromDir . DIRECTORY_SEPARATOR . $object));
 		                }
 		            }
 			


### PR DESCRIPTION
For windows users that have paths with a back slash, you may experience the following when you upload a file:

http://i49.tinypic.com/fay5v6.png

For some reason, Amazon will make this part of the URL, so we simply need to change the back slash into a forward slash so that directories are preserved.
