### PR TITLE
Proper handling of STDOUT and STDERR

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -197,10 +197,10 @@ class Phing {
      */
     private static function initializeOutputStreams() {
         if (self::$out === null) {
-            self::$out = new OutputStream(fopen("php://stdout", "w"));
+            self::$out = new OutputStream(STDOUT);
         }
         if (self::$err === null) {
-            self::$err = new OutputStream(fopen("php://stderr", "w"));
+            self::$err = new OutputStream(STDERR);
         }
     }
 


### PR DESCRIPTION
I have found a serious bug. When phing is spawning a process and is executed by SSH, the sshd process hangs. It happens because fopen("php://stdout", "w") creates a copy od STDOUT (according to http://php.net/manual/en/wrappers.php.php). In general - usage of constants STDOUT and STDERR is recomended. 
The bug is also visible when an execTask runs a script which spawns a process.

Thanks

Tymoteusz
