### PR TITLE
add phing.dir property for unit tests

### DIFF
--- a/test/classes/phing/BuildFileTest.php
+++ b/test/classes/phing/BuildFileTest.php
@@ -200,6 +200,7 @@ abstract class BuildFileTest extends PHPUnit_Framework_TestCase {
         $this->project->init();
         $f = new PhingFile($filename);
         $this->project->setUserProperty( "phing.file" , $f->getAbsolutePath() );
+        $this->project->setUserProperty( "phing.dir"  , dirname($f->getAbsolutePath()) );
         $this->project->addBuildListener(new PhingTestListener($this));
         ProjectConfigurator::configureProject($this->project, new PhingFile($filename));
     }


### PR DESCRIPTION
While testing my PearPackageFileSet enhancement (see PR-174) I saw that the unit tests does not provided the _phing.dir_ property support as phing core did [1]

Of course, we can add temporary support as I did it. [2]  lines 7 to 14

But it would be better if it will integrate in phing test core !
- Laurent

[1] https://github.com/phingofficial/phing/blob/master/classes/phing/Phing.php#L512
[2] https://github.com/llaville/phing/blob/d65a62d22cfdfac6855ad588b4f76f9165e8f571/test/etc/types/PearPackageFileSetBuildTest.xml
