### PR TITLE
ScpTask: fallback for "ssh2_scp_send" when remote server won't allow it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .buildpath
 .project
 .settings
+.idea
 build/full
 build/pear
 test/reports

--- a/classes/phing/tasks/ext/ssh/ScpTask.php
+++ b/classes/phing/tasks/ext/ssh/ScpTask.php
@@ -268,7 +268,27 @@ class ScpTask extends Task
     {
         return $this->fetch;
     }
-    
+
+    /**
+     * Declare number of successful operations above which "sftp" will be chosen over "scp".
+     *
+     * @param int $heuristicDecision    Number
+     */
+    public function setHeuristicDecision($heuristicDecision)
+    {
+        $this->heuristicDecision = (int) $heuristicDecision;
+    }
+
+    /**
+     * Get declared number of successful operations above which "sftp" will be chosen over "scp".
+     *
+     * @return int
+     */
+    public function getHeuristicDecision()
+    {
+        return $this->heuristicDecision;
+    }
+
     /**
      * Nested creator, creates a FileSet for this task
      *


### PR DESCRIPTION
Sometimes remote server allow only create files via sftp and won't allow scp.

For example: phpcloud.com
- how to deploy: http://www.phpcloud.com/help/sftp-help
- no possibility to login`ssh  someapp@someapp.my.phpcloud.com` returns:

```
Connection to someapp.my.phpcloud.com closed.
Transferred: sent 2848, received 2344 bytes, in 1.6 seconds
Bytes per second: sent 1754.5, received 1444.0
debug1: Exit status 1
```
- no possibility to run `scp -v text.txt someapp@someapp.my.phpcloud.com:/c.txt` which returns:

```
Transferred: sent 2544, received 2328 bytes, in 4.0 seconds
Bytes per second: sent 630.6, received 577.1
debug1: Exit status 128
lost connection
```

So, this pull request is my solution for this problem.
To do it as a separate task will only duplicate code, do I chose this solution.

What do you think of it?
