### PR TITLE
improved verbose level message for debugging in ImportTask

### DIFF
--- a/classes/phing/tasks/system/ImportTask.php
+++ b/classes/phing/tasks/system/ImportTask.php
@@ -127,7 +127,7 @@ class ImportTask extends Task {
       // Since this is delayed until after the importing file has been 
       // processed, the properties and targets of this new file may not take 
       // effect if they have alreday been defined in the outer scope.
-      $this->log("Importing configuration from {$file->getName()}", Project::MSG_VERBOSE);
+      $this->log("Importing configuration from {$file->getAbsolutePath()}", Project::MSG_VERBOSE);
       ProjectConfigurator::configureProject($this->project, $file);
       $this->log("Configuration imported.", Project::MSG_VERBOSE);
     }


### PR DESCRIPTION
While I worked on a phing solution to build-docs/package my pear packages, based on a series of modules all named build.xml into subdirectories, 

I found difficult to debug where come the problem while reading the log contents, because we always
have the basename of the script.

With the phing tests import scripts it's not difficult to find origin because we have 

```
[import] Importing configuration from imported.xml
[import] Importing configuration from importedImport.xml
```

But I'd prefere to have such results : 

```
[import] Importing configuration from \home\github\phing\test\etc\tasks\imports\imported.xml
[import] Importing configuration from \home\github\phing\test\etc\tasks\imports\importedImport.xml
```

Especially in case of base scriptname equals
- Laurent 
