### PR TITLE
Git tasks - pass real error message (2nd version)

### DIFF
--- a/classes/phing/tasks/ext/git/GitBaseTask.php
+++ b/classes/phing/tasks/ext/git/GitBaseTask.php
@@ -120,7 +120,7 @@ abstract class GitBaseTask extends Task
             } catch (VersionControl_Git_Exception $e) {
                 // re-package
                 throw new BuildException(
-                    'You must specify readable directory as repository.');
+                    'You must specify readable directory as repository.', $e);
 
             }
         }

--- a/classes/phing/tasks/ext/git/GitBranchTask.php
+++ b/classes/phing/tasks/ext/git/GitBranchTask.php
@@ -139,7 +139,7 @@ class GitBranchTask extends GitBaseTask
         try {
             $output = $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed.');
+            throw new BuildException('Task execution failed.', $e);
         }
 
         $this->log(

--- a/classes/phing/tasks/ext/git/GitCheckoutTask.php
+++ b/classes/phing/tasks/ext/git/GitCheckoutTask.php
@@ -118,7 +118,7 @@ class GitCheckoutTask extends GitBaseTask
         try {
             $output = $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed.');
+            throw new BuildException('Task execution failed.', $e);
         }
 
         $this->log(

--- a/classes/phing/tasks/ext/git/GitCloneTask.php
+++ b/classes/phing/tasks/ext/git/GitCloneTask.php
@@ -74,7 +74,7 @@ class GitCloneTask extends GitBaseTask
                 $this->isBare(), 
                 $this->getTargetPath());
         } catch (Exception $e) {
-            throw new BuildException('The remote end hung up unexpectedly');
+            throw new BuildException('The remote end hung up unexpectedly', $e);
         }
 
         $msg = 'git-clone: cloning ' 

--- a/classes/phing/tasks/ext/git/GitCommitTask.php
+++ b/classes/phing/tasks/ext/git/GitCommitTask.php
@@ -82,7 +82,7 @@ class GitCommitTask extends GitBaseTask
         	$command->setOptions($options);
         	$command->execute();
         } catch (Exception $e) {
-            throw new BuildException('The remote end hung up unexpectedly');
+            throw new BuildException('The remote end hung up unexpectedly', $e);
         }
 
         $msg = 'git-commit: Executed git commit ';

--- a/classes/phing/tasks/ext/git/GitFetchTask.php
+++ b/classes/phing/tasks/ext/git/GitFetchTask.php
@@ -137,7 +137,7 @@ class GitFetchTask extends GitBaseTask
         try {
             $output = $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed.');
+            throw new BuildException('Task execution failed.', $e);
         }
 
         $this->log(

--- a/classes/phing/tasks/ext/git/GitGcTask.php
+++ b/classes/phing/tasks/ext/git/GitGcTask.php
@@ -83,7 +83,7 @@ class GitGcTask extends GitBaseTask
         try {
             $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed');
+            throw new BuildException('Task execution failed', $e);
         }
 
         $this->log(

--- a/classes/phing/tasks/ext/git/GitLogTask.php
+++ b/classes/phing/tasks/ext/git/GitLogTask.php
@@ -139,7 +139,7 @@ class GitLogTask extends GitBaseTask
         try {
             $output = $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed');
+            throw new BuildException('Task execution failed', $e);
         }
 
         if (null !== $this->outputProperty) {

--- a/classes/phing/tasks/ext/git/GitMergeTask.php
+++ b/classes/phing/tasks/ext/git/GitMergeTask.php
@@ -146,7 +146,7 @@ class GitMergeTask extends GitBaseTask
         try {
             $output = $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed.');
+            throw new BuildException('Task execution failed.', $e);
         }
 
         $this->log(

--- a/classes/phing/tasks/ext/git/GitPullTask.php
+++ b/classes/phing/tasks/ext/git/GitPullTask.php
@@ -187,7 +187,7 @@ class GitPullTask extends GitBaseTask
         try {
             $output = $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed.');
+            throw new BuildException('Task execution failed.', $e);
         }
 
         $this->log('git-pull: complete', Project::MSG_INFO); 

--- a/classes/phing/tasks/ext/git/GitPushTask.php
+++ b/classes/phing/tasks/ext/git/GitPushTask.php
@@ -129,7 +129,7 @@ class GitPushTask extends GitBaseTask
         try {
             $output = $command->execute();
         } catch (Exception $e) {
-            throw new BuildException('Task execution failed.');
+            throw new BuildException('Task execution failed.', $e);
         }
 
         $this->log('git-push: complete', Project::MSG_INFO); 


### PR DESCRIPTION
I was using the task gitcheckout yesterday, and the task failed with no other message than "Task execution failed". Looking at the source in phing/tasks/ext/git/GitCheckoutTask.php I see that all execution errors are handled by
throw new BuildException('Task execution failed.');
I have changed it to 
throw new BuildException('Task execution failed.', $e);

Same treatment applied to all the git tasks.

Thanks to MichaelPhing @ IRC for quick replies.
