### PR TITLE
Phar Stub is optional - fix PHP Error

### DIFF
--- a/classes/phing/tasks/ext/phar/PharPackageTask.php
+++ b/classes/phing/tasks/ext/phar/PharPackageTask.php
@@ -383,7 +383,7 @@ class PharPackageTask
             $phar->setSignatureAlgorithm($this->signatureAlgorithm);
         }
 
-        if (isset($this->stubPath)) {
+        if (!empty($this->stubPath)) {
             $phar->setStub(file_get_contents($this->stubPath));
         } else {
             if (!empty($this->cliStubFile)) {


### PR DESCRIPTION
When we use a reusable code written such as follow 

```
<?xml version="1.0" encoding="UTF-8"?>
<project name="phar" description="Build phar archive" default="do">

    <property name="phar.basedir"    value="${env.TMP}/${phing.project.name}" />
    <property name="phar.destfile"   value="myproject.phar" />
    <property name="phar.stub"       value="" />

    <target name="do">
        <mkdir dir="${phar.basedir}" />

        <pharpackage
            basedir="${phar.basedir}"
            destfile="${phar.destfile}"
            stub="${phar.stub}"
        >
            <fileset dir="${phar.basedir}" />
        </pharpackage>
    </target>

</project>
```

And when the stub attribute is empty, then we got a PHP Error like that 

```
[PHP Error] file_get_contents(): Filename cannot be empty [line 387 of C:\UwAmp\bin\php\php-5.3.21\includes\phing\tasks\ext\phar\PharPackageTask.php]
```

With this PR, the phar archive was built 
- Laurent 
