### PR TITLE
PhpCodeSniffer - changed format of ignorePatterns

### DIFF
--- a/classes/phing/tasks/ext/PhpCodeSnifferTask.php
+++ b/classes/phing/tasks/ext/PhpCodeSnifferTask.php
@@ -232,7 +232,7 @@ class PhpCodeSnifferTask extends Task {
         $token = ' ,;';
         $pattern = strtok($patterns, $token);
         while ($pattern !== false) {
-            $this->ignorePatterns[] = $pattern;
+            $this->ignorePatterns[$pattern] = 'relative';
             $pattern = strtok($token);
         }
     }


### PR DESCRIPTION
New format was introduced in PHP_CodeSniffer version 1.4.1

Example:

array('path' => 'relative', '/path2' => 'absolute')
