### PR TITLE
Make phing to work properly if the base dir is a symlink

### DIFF
--- a/classes/phing/Project.php
+++ b/classes/phing/Project.php
@@ -488,6 +488,7 @@ class Project {
         }
 
         $dir = $this->fileUtils->normalize($dir);
+        $dir = FileSystem::canonicalize($dir);
 
         $dir = new PhingFile((string) $dir);
         if (!$dir->exists()) {


### PR DESCRIPTION
This is supposed to address the problem when phing complains if the base dir is a symlink to another directory without affecting any other symlink-resolution logic. See also:
https://github.com/phingofficial/phing/pull/132
