### PR TITLE
Minor fix for filesync task

### DIFF
--- a/classes/phing/tasks/defaults.properties
+++ b/classes/phing/tasks/defaults.properties
@@ -121,6 +121,7 @@ jsmin=phing.tasks.ext.jsmin.JsMinTask
 version=phing.tasks.ext.VersionTask
 filehash=phing.tasks.ext.FileHashTask
 filesize=phing.tasks.ext.FileSizeTask
+filesync=phing.tasks.ext.FileSyncTask
 xmlproperty=phing.tasks.ext.XmlPropertyTask
 exportproperties=phing.tasks.ext.ExportPropertiesTask
 http-request=phing.tasks.ext.HttpRequestTask

--- a/docs/phing_guide/book/chapters/appendixes/AppendixC-OptionalTasks.html
+++ b/docs/phing_guide/book/chapters/appendixes/AppendixC-OptionalTasks.html
@@ -882,9 +882,9 @@ file_put_contents('/www/live/testcases/coverage.data', serialize(xdebug_get_code
 		   same server or from/to a remote server.</p>
 		<h3>Example</h3>
 		<pre>
-&lt;sync sourcedir="/var/www/development/project1" destinationdir="/var/www/project1" /&gt;
+&lt;filesync sourcedir="/var/www/development/project1" destinationdir="/var/www/project1" /&gt;
 
-&lt;sync
+&lt;filesync
 sourcedir="/var/www/development/project1"
 destinationdir="user@server:/var/www/project1"
 dryrun="true"


### PR DESCRIPTION
The file sync task was missing from the default.properties file, causing it not to be picked up by phing. The documentation also incorrectly called it using <sync ...> in the example code instead of <filesync ...>
