### PR TITLE
Typo fix in writing tasks documentation

### DIFF
--- a/docs/docbook5/en/source/chapters/extending.xml
+++ b/docs/docbook5/en/source/chapters/extending.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model xlink:href="http://www.oasis-open.org/docbook/xml/5.0/rng/docbookxi.rng" 
+<?xml-model xlink:href="http://www.oasis-open.org/docbook/xml/5.0/rng/docbookxi.rng"
             schematypens="http://relaxng.org/ns/structure/1.0"?>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
     xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="ch.extending">
@@ -18,7 +18,7 @@
                 xlink:href="#sect.ext.tasks"/>, <xref xlink:href="#sect.ext.types" xlink:title="Types"/>, <xref
                 xlink:href="#sect.ext.mappers" xlink:title="Mappers"/>. The following sections discuss these
             options.</para>
- 
+
         <sect2 xml:id="sect.ext.tasks" xreflabel="Tasks">
             <title> Tasks </title>
 
@@ -435,7 +435,7 @@ class MyEchoTask extends Task {
         <sect2>
             <title>Source Discussion </title>
 
-            <para>No that you've got the knowledge to execute the task in a buildfile it's time to
+            <para>Now that you've got the knowledge to execute the task in a buildfile it's time to
                 discuss how everything works.</para>
 
         </sect2>

--- a/docs/phing_guide/book/chapters/ExtendingPhing.html
+++ b/docs/phing_guide/book/chapters/ExtendingPhing.html
@@ -452,7 +452,7 @@ class MyEchoTask extends Task {
 		<a name="SourceDiscussion"></a>Source Discussion
 	</h3>
 
-	<p>No that you've got the knowledge to execute the task in a
+	<p>Now that you've got the knowledge to execute the task in a
 		buildfile it's time to discuss how everything works.</p>
 
 	<h3>


### PR DESCRIPTION
Very minor typo:

"No that you've got the knowledge to execute the task in a buildfile it's time to discuss how everything works."

should be:

"Now that you've got the knowledge to execute the task in a buildfile it's time to discuss how everything works."
