### PR TITLE
Bug fix for spaces in paths in file sync task

### DIFF
--- a/classes/phing/tasks/ext/FileSyncTask.php
+++ b/classes/phing/tasks/ext/FileSyncTask.php
@@ -280,16 +280,16 @@ class FileSyncTask extends Task
             $options .= ' --itemize-changes';
         }
         if ($this->backupDir !== null) {
-            $options .= ' -b --backup-dir=' . $this->backupDir;
+            $options .= ' -b --backup-dir="' . $this->backupDir . '"';
         }
         
         if ($this->excludeFile !== null) {
-            $options .= ' --exclude-from=' . $this->excludeFile;
+            $options .= ' --exclude-from="' . $this->excludeFile . '"';
         }
 
         $this->setOptions($options);
 
-        $options .= ' ' . $this->sourceDir . ' ' . $this->destinationDir;
+        $options .= ' "' . $this->sourceDir . '" "' . $this->destinationDir . '"';
 
         escapeshellcmd($options);
         $options .= ' 2>&1';


### PR DESCRIPTION
If the paths provided to the file sync task contain spaces the underlying rsync command fails. This patch puts quotes around all the paths passed into rsync to prevent this issue.
