### PR TITLE
Loosened checks for PHPCPDTask and PHPLocTask

### DIFF
--- a/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
+++ b/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
@@ -211,21 +211,21 @@ class PHPCPDTask extends Task
         /**
          * Determine PHPCPD installation
          */
-        
+
         @include_once('SebastianBergmann/PHPCPD/autoload.php');
         @include_once('PHPCPD/Autoload.php');
-        
+
         if (!class_exists('SebastianBergmann\PHPCPD\Version')) {
             throw new BuildException("PHPCPDTask requires PHPCPD to be installed", $this->getLocation());
         }
 
-        $version = SebastianBergmann\PHPCPD\Version::id();
+        $version = call_user_func('SebastianBergmann\PHPCPD\Version', 'id');
         $oldVersion = (version_compare($version, '1.4.0') < 0);
-        
+
         if (!$oldVersion && version_compare(PHP_VERSION, '5.3.0') < 0) {
             throw new BuildException("The PHPCPD task now requires PHP 5.3+");
         }
-        
+
         if (!isset($this->_file) and count($this->_filesets) == 0) {
             throw new BuildException(
                 "Missing either a nested fileset or attribute 'file' set"
@@ -260,7 +260,7 @@ class PHPCPDTask extends Task
         }
 
         $this->log('Processing files...');
-        
+
         if ($oldVersion) {
             $detectorClass = 'PHPCPD_Detector';
             $strategyClass = 'PHPCPD_Detector_Strategy_Default';
@@ -268,7 +268,7 @@ class PHPCPDTask extends Task
             $detectorClass = '\\SebastianBergmann\\PHPCPD\\Detector\\Detector';
             $strategyClass = '\\SebastianBergmann\\PHPCPD\\Detector\\Strategy\\DefaultStrategy';
         }
-        
+
         $detector = new $detectorClass(new $strategyClass);
         $clones   = $detector->copyPasteDetection(
             $filesToParse,


### PR DESCRIPTION
Currently, phing fails if the relevant include files are not found for the PHPCPDTask and PHPLocTask. This doesn't work very well when trying to use PHPCPD and PHPLOC from the Composer vendor directory. I changed the code to not require these includes to succeed, but rather only to require that the relevant classes exist.
