### PR TITLE
Fixed reset color in AnsiColorLogger

### DIFF
--- a/classes/phing/listener/AnsiColorLogger.php
+++ b/classes/phing/listener/AnsiColorLogger.php
@@ -128,7 +128,7 @@ class AnsiColorLogger extends DefaultLogger {
     const PREFIX = "\x1b[";
     const SUFFIX = "m";
     const SEPARATOR = ';';
-    const END_COLOR = "\x1b[m"; // self::PREFIX . self::SUFFIX;
+    const END_COLOR = "\x1b[0m"; // self::PREFIX . self::SUFFIX;
 
     private $errColor;
     private $warnColor;


### PR DESCRIPTION
Simple fix in order to be consistent with the specification.
