### PR TITLE
Composer: Fixed bug with incorrect arguments placement in generated command line

### DIFF
--- a/classes/phing/tasks/ext/ComposerTask.php
+++ b/classes/phing/tasks/ext/ComposerTask.php
@@ -134,8 +134,9 @@ class ComposerTask extends Task
     private function prepareCommandLine()
     {
         $this->commandLine->setExecutable($this->getPhp());
-        $this->commandLine->createArgument()->setValue($this->getComposer());
-        $this->commandLine->createArgument()->setValue($this->getCommand());
+        //We are un-shifting arguments to the beginning of the command line because arguments should be at the end
+        $this->commandLine->createArgument(true)->setValue($this->getCommand());
+        $this->commandLine->createArgument(true)->setValue($this->getComposer());
         $commandLine = strval($this->commandLine);
         //Creating new Commandline instance. It allows to handle subsequent calls correctly
         $this->commandLine = new Commandline();

--- a/test/classes/phing/tasks/ext/ComposerTaskTest.php
+++ b/test/classes/phing/tasks/ext/ComposerTaskTest.php
@@ -101,10 +101,12 @@ class ComposerTaskTest extends PHPUnit_Framework_TestCase
         }
         $o = $this->object;
         $o->setCommand('install');
+        $o->createArg()->setValue('--dry-run');
         $method = new ReflectionMethod('ComposerTask', 'prepareCommandLine');
         $method->setAccessible(true);
-        $this->assertEquals('php composer.phar install', strval($method->invoke($o)));
-        $this->assertEquals('php composer.phar install', strval($method->invoke($o)));
+        $this->assertEquals('php composer.phar install --dry-run', strval($method->invoke($o)));
+        $o->setCommand('update');
+        $o->createArg()->setValue('--dev');
+        $this->assertEquals('php composer.phar update --dev', strval($method->invoke($o)));
     }
-
 }


### PR DESCRIPTION
Unfortunately I introduced a new bug with my previous bugfix: Composer command line was generated incorrectly if there were arguments:
`php --arg composer.phar install` instead of `php composer.phar install --arg`

This commit fixes the bug and adds more conditions in unit test.
