### PR TITLE
Make phar executable

### DIFF
--- a/build/phing-stub.php
+++ b/build/phing-stub.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 if (DIRECTORY_SEPARATOR != '\\' && function_exists('posix_isatty') && @posix_isatty(STDOUT)) {


### PR DESCRIPTION
Executing phing.phar didn't use PHP as its interpreter
