### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "include-path": ["classes"],
     "bin": [
-        "composer/bin/phing"
+        "bin/phing"
     ],
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Phing binary is not getting copied to vendor/composer/bin with error: "Skipped installation of composer/bin/phing for package phing/phing: file not found in package".

Path to phing binary needs to be relative to package root directory.
