### PR TITLE
Fix documented but not working "PropertyTask refid" feature

### DIFF
--- a/classes/phing/Project.php
+++ b/classes/phing/Project.php
@@ -25,6 +25,7 @@ include_once 'phing/TaskAdapter.php';
 include_once 'phing/util/StringHelper.php';
 include_once 'phing/BuildEvent.php';
 include_once 'phing/input/DefaultInputHandler.php';
+include_once 'phing/types/PropertyValue.php';
 
 /**
  *  The Phing project class. Represents a completely configured Phing project.
@@ -210,6 +211,7 @@ class Project {
 
         $this->log("Setting project property: " . $name . " -> " . $value, Project::MSG_DEBUG);
         $this->properties[$name] = $value;
+        $this->addReference($name, new PropertyValue($value));
     }
 
     /**
@@ -230,6 +232,7 @@ class Project {
         }
         $this->log("Setting project property: " . $name . " -> " . $value, Project::MSG_DEBUG);
         $this->properties[$name] = $value;
+        $this->addReference($name, new PropertyValue($value));
     }
 
     /**
@@ -245,6 +248,7 @@ class Project {
         $this->log("Setting user project property: " . $name . " -> " . $value, Project::MSG_DEBUG);
         $this->userProperties[$name] = $value;
         $this->properties[$name] = $value;
+        $this->addReference($name, new PropertyValue($value));
     }
 
     /**
@@ -278,6 +282,7 @@ class Project {
             return;
         }
         $this->properties[$name] = $value;
+        $this->addReference($name, new PropertyValue($value));
     }
 
     /**

--- a/classes/phing/tasks/system/PropertyTask.php
+++ b/classes/phing/tasks/system/PropertyTask.php
@@ -216,7 +216,7 @@ class PropertyTask extends Task {
      */
     function main() {
         if ($this->name !== null) {
-            if ($this->value === null && $this->ref === null) {
+            if ($this->value === null && $this->reference === null) {
                 throw new BuildException("You must specify value or refid with the name attribute", $this->getLocation());
             }
         } else {
@@ -241,7 +241,7 @@ class PropertyTask extends Task {
             $this->loadEnvironment($this->env);
         }
 
-        if (($this->name !== null) && ($this->ref !== null)) {
+        if (($this->name !== null) && ($this->reference !== null)) {
             // get the refereced property
             try {
             $this->addProperty($this->name, $this->reference->getReferencedObject($this->project)->toString());

--- a/classes/phing/types/PropertyValue.php
+++ b/classes/phing/types/PropertyValue.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+/** Class to hold a property value
+ *  Class only required to make it possible to add a property as reference
+ * @package phing.types
+ */
+class PropertyValue {
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Constructor optionaly sets a the value of property component.
+     * @param    mixed      Value of name, all scalars allowed
+     */
+    function __construct($value = null) {
+        if ($value !== null) {
+            $this->setValue($value);
+        }
+    }
+
+    /**
+     * Sets a the value of property component.
+     * @param    mixed      Value of name, all scalars allowed
+     */
+    function setValue($value) {
+        $this->value = (string) $value;
+    }
+
+    /** Get the value of property component. */
+    function getValue() {
+        return $this->value;
+    }
+
+    function toString() {
+        return $this->getValue();
+    }
+}
+


### PR DESCRIPTION
According to documentation `PropertyTask` supports an `refid` attribute to reference a previously defined property - but this currently ain't working.

The PR solve this issue and make the following example scenario possible:

Define properties e.g. in _build.properties_

```
my.property.definitons = 1,2
my.property.definiton.1 = foo
my.property.definiton.2 = bar
```

Dynamicly access properties in a build file

``` xml
<foreach list="${my.property.definitons}" param="key" target="subtask" />

<!-- within target subtask -->
<property name="value" refid="my.property.definiton.${key}" />
<echo message="my.property.definiton.${key} is ${value}" />
```

**Note**
Adding reference within `Project::setPropertyInternal` should be reviewed, if it has negative side effects - even none occurred in my scenarios yet.
