### PR TITLE
Resolve relative symlinks in AvailableTask.

### DIFF
--- a/classes/phing/tasks/system/AvailableTask.php
+++ b/classes/phing/tasks/system/AvailableTask.php
@@ -165,13 +165,19 @@ class AvailableTask extends Task {
     private function _checkFile1(PhingFile $file) {
         // Resolve symbolic links
         if ($this->followSymlinks && $file->isLink()) {
-            $fs = FileSystem::getFileSystem();
-            $file = new PhingFile(
-                $fs->resolve(
-                    $fs->normalize($file->getParent()),
-                    $fs->normalize($file->getLinkTarget())
-                )
-            );
+            $linkTarget = new PhingFile($file->getLinkTarget());
+            if ($linkTarget->isAbsolute()) {
+                $file = $linkTarget;
+            }
+            else {
+                $fs = FileSystem::getFileSystem();
+                $file = new PhingFile(
+                    $fs->resolve(
+                        $fs->normalize($file->getParent()),
+                        $fs->normalize($file->getLinkTarget())
+                    )
+                );
+            }
         }
 
         if ($this->type !== null) {

--- a/test/classes/phing/tasks/system/AvailableTaskTest.php
+++ b/test/classes/phing/tasks/system/AvailableTaskTest.php
@@ -58,7 +58,19 @@ class AvailableTaskTest extends BuildFileTest
         $this->assertEquals('true', $this->project->getProperty("prop." . __FUNCTION__));
     }
 
+    public function testFileAbsoluteSymlink()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertEquals('true', $this->project->getProperty("prop." . __FUNCTION__));
+    }
+
     public function testDirectorySymlink()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertEquals('true', $this->project->getProperty("prop." . __FUNCTION__));
+    }
+
+    public function testDirectoryAbsoluteSymlink()
     {
         $this->executeTarget(__FUNCTION__);
         $this->assertEquals('true', $this->project->getProperty("prop." . __FUNCTION__));

--- a/test/etc/tasks/system/AvailableTaskTest.xml
+++ b/test/etc/tasks/system/AvailableTaskTest.xml
@@ -25,12 +25,26 @@
 		property="prop.testFileSymlink" />
 	</target>
 	
+	<target name="testFileAbsoluteSymlink">
+		<symlink target="${phing.file}" link="${tmp.dir}/a"/>
+		<available file="${tmp.dir}/a" type="file"
+		followSymlinks="true"
+		property="prop.testFileAbsoluteSymlink" />
+	</target>
+	
 	<target name="testDirectorySymlink">
 		<mkdir dir="${tmp.dir}/c"/>
 		<symlink target="c" link="${tmp.dir}/d"/>
 		<available file="${tmp.dir}/d" type="dir"
 		followSymlinks="true"
 		property="prop.testDirectorySymlink" />
+	</target>
+	
+	<target name="testDirectoryAbsoluteSymlink">
+		<symlink target="${phing.dir}" link="${tmp.dir}/d"/>
+		<available file="${tmp.dir}/d" type="dir"
+		followSymlinks="true"
+		property="prop.testDirectoryAbsoluteSymlink" />
 	</target>
 	
     <target name="testDirectorySymlinkBC">


### PR DESCRIPTION
When followSymlinks is used in AvailableTask, it will only work when the symlink target is given as an absolute path.
This patch makes it work when the target is a relative path too.
