### PR TITLE
Loosen checks for PHPCPDTask/PHPLocTask.

### DIFF
--- a/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
+++ b/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
@@ -213,7 +213,7 @@ class PHPCPDTask extends Task
          */
         $oldVersion = false;
         
-        if (!class_exists('\\SebastianBergmann\\PHPCPD\\TextUI\\Command') &&
+        if (!class_exists('\\SebastianBergmann\\PHPCPD\\Detector\\Strategy\\DefaultStrategy') &&
             !@include_once('SebastianBergmann/PHPCPD/autoload.php')) {
             if (!@include_once('PHPCPD/Autoload.php')) {
                 throw new BuildException(

--- a/classes/phing/tasks/ext/phploc/PHPLocTask.php
+++ b/classes/phing/tasks/ext/phploc/PHPLocTask.php
@@ -101,7 +101,7 @@ class PHPLocTask extends Task
         /**
          * Find PHPLoc
          */
-        if (!class_exists('\\SebastianBergmann\\PHPLOC\\TextUI\\Command') &&
+        if (!class_exists('\\SebastianBergmann\\PHPLOC\\Analyse') &&
             !@include_once('SebastianBergmann/PHPLOC/autoload.php')) {
             if (!@include_once('PHPLOC/Analyser.php')) {
                 throw new BuildException(


### PR DESCRIPTION
This makes these two tasks work correctly when phing is run from composer (and hence, composer's autoloader is used in place of include_path).
The patch is based on a previous pull request by @joshuaspence (see #195)
