### PR TITLE
Setting location on exceptions only if present

### DIFF
--- a/classes/phing/Task.php
+++ b/classes/phing/Task.php
@@ -261,7 +261,7 @@ abstract class Task extends ProjectComponent {
             $this->project->fireTaskFinished($this, $null=null);
         } catch (Exception $exc) {
             if ($exc instanceof BuildException) {
-                if ($exc->getLocation() === null) {
+                if ($exc->getLocation() !== null) {
                     $exc->setLocation($this->getLocation());
                 }
             }


### PR DESCRIPTION
Without this change, exceptions throw in AdHocTasks cause the build to fail with:

```
[PHP Error] Argument 1 passed to BuildException::setLocation() must be an instance of Location, null given, called in /usr/share/php/phing/Task.php on line 265 and defined [line 119 of /usr/share/php/phing/BuildException.php]
```

instead of showing the original error.
