### PR TITLE
Fix undefined var in ScpTask

### DIFF
--- a/classes/phing/tasks/ext/ssh/ScpTask.php
+++ b/classes/phing/tasks/ext/ssh/ScpTask.php
@@ -449,6 +449,6 @@ class ScpTask extends Task
             }
         }
 
-        $this->count++;
+        $this->counter++;
     }
 }


### PR DESCRIPTION
ScpTask will raise a notice because of undefined variable "counter". 
