### PR TITLE
Fixes #1027 RegexpMapper uses deprecated PREG_REPLACE_EVAL

### DIFF
--- a/classes/phing/mappers/RegexpMapper.php
+++ b/classes/phing/mappers/RegexpMapper.php
@@ -87,11 +87,18 @@ class RegexpMapper implements FileNameMapper {
         
         // the expression has already been processed (when ->matches() was run in Main())
         // so no need to pass $source again to the engine.
-        $groups = (array) $this->reg->getGroups();            
         
-        // replace \1 with value of $groups[1] and return the modified "to" string
-        return preg_replace('/\\\([\d]+)/e', "\$groups[$1]", $this->to);            
+        // replace \1 with value of reg->getGroup(1) and return the modified "to" string
+        return preg_replace_callback('/\\\([\d]+)/', array($this, 'replaceReferencesCallback'), $this->to);            
     }
     
+    /**
+     * Gets the matched group from the Regexp engine.
+     * @param array $matches Matched elements.
+     */
+    private function replaceReferencesCallback($matches) {
+        return (string) $this->reg->getGroup($matches[1]);
+    }
+
 }
 


### PR DESCRIPTION
Please let me know if anything's not up to par.
