### PR TITLE
Test if property was set, instead of testing for non-null value

### DIFF
--- a/classes/phing/parser/ProjectConfigurator.php
+++ b/classes/phing/parser/ProjectConfigurator.php
@@ -388,7 +388,7 @@ class ProjectConfigurator
     private static function replacePropertyCallback($matches)
     {
         $propertyName = $matches[1];
-        if (!isset(self::$propReplaceProperties[$propertyName])) {
+        if (!array_key_exists($propertyName, self::$propReplaceProperties)) {
             self::$propReplaceProject->log(
                 'Property ${' . $propertyName . '} has not been set.',
                 self::$propReplaceLogLevel


### PR DESCRIPTION
Allows to set properties to null. Needed when from the programmatic point of view "" != null

Please test and review if it makes sense. I'm not sure if the null value test was not intentional - but for me it was a bug as it reported null-set property as undefined => it won't replace it. 