### PR TITLE
Added a backwards compatible fallback to the changes made in PR #173

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -199,10 +199,18 @@ class Phing {
      */
     private static function initializeOutputStreams() {
         if (self::$out === null) {
-            self::$out = new OutputStream(STDOUT);
+            if (!defined('STDOUT')) {
+              self::$out = new OutputStream(fopen('php://stdout', 'w'));
+            } else {
+              self::$out = new OutputStream(STDOUT);
+            }
         }
         if (self::$err === null) {
-            self::$err = new OutputStream(STDERR);
+            if (!defined('STDERR')) {
+              self::$out = new OutputStream(fopen('php://stderr', 'w'));
+            } else {
+              self::$err = new OutputStream(STDERR);
+            }
         }
     }
 


### PR DESCRIPTION
The constants STDOUT and STDERR are not available if calling out to Phing from a script running under apache. This PR adds a check for their existence, and falls back to calling fopen.
