### PR TITLE
Allow PhpDocumentor2 path to be found if installed via composer

### DIFF
--- a/classes/phing/tasks/ext/phpdoc/PhpDocumentor2Wrapper.php
+++ b/classes/phing/tasks/ext/phpdoc/PhpDocumentor2Wrapper.php
@@ -123,15 +123,7 @@ class PhpDocumentor2Wrapper
      */
     private function initializePhpDocumentor()
     {
-        $phpDocumentorPath = null;
-        
-        foreach (Phing::explodeIncludePath() as $path) {
-            $testPhpDocumentorPath = $path . DIRECTORY_SEPARATOR . 'phpDocumentor' . DIRECTORY_SEPARATOR . 'src';
-
-            if (file_exists($testPhpDocumentorPath)) {
-                $phpDocumentorPath = $testPhpDocumentorPath;
-            }
-        }
+        $phpDocumentorPath = $this->findPhpDocumentorPath();
 
         if (empty($phpDocumentorPath)) {
             throw new BuildException("Please make sure PhpDocumentor 2 is installed and on the include_path.");
@@ -226,5 +218,26 @@ class PhpDocumentor2Wrapper
         $this->project->log("Transforming...", Project::MSG_VERBOSE);
         
         $this->transformFiles();
+    }
+
+    /**
+     * Find the correct php documentor path
+     *
+     * @return null|string
+     */
+    private function findPhpDocumentorPath()
+    {
+        $phpDocumentorPath = null;
+        $directories = array('phpDocumentor', 'phpdocumentor');
+        foreach ($directories as $directory) {
+            foreach (Phing::explodeIncludePath() as $path) {
+                $testPhpDocumentorPath = $path . DIRECTORY_SEPARATOR . $directory . DIRECTORY_SEPARATOR . 'src';
+                if (file_exists($testPhpDocumentorPath)) {
+                    $phpDocumentorPath = $testPhpDocumentorPath;
+                }
+            }
+        }
+
+        return $phpDocumentorPath;
     }
 }


### PR DESCRIPTION
If PhpDocumentor 2 is installed via composer it's unable to find to correct include path on system that's case sensitive.

Composer creates following directory structure **vendor/phpdocumentor/phpdocumentor** but phing expects it to be **vendor/phpdocumentor/phpDocumentor**.
This PR solves this as it will try first to find the one with the case sensitive path afterwards the lowercase one.

Example build file:

``` xml
<?xml version="1.0" encoding="UTF-8" ?>
<project name="myapp" default="help" basedir=".">
    <property name="basedir" value="${project.basedir}" />
    <property name="builddir" value="${basedir}/build" />
    <property name="source" value="${basedir}" />

    <target name="phpdoc">
        <includepath classpath="${basedir}/vendor/phpdocumentor" />
        <phpdoc2 title="API Documentation" destdir="${builddir}/docs" template="zend">
            <fileset dir="${source}">
                <patternset refid="defaultSet" />
            </fileset>
        </phpdoc2>
    </target>
```
