### PR TITLE
Fix exception in phing error handling

### DIFF
--- a/classes/phing/system/io/FileOutputStream.php
+++ b/classes/phing/system/io/FileOutputStream.php
@@ -42,6 +42,7 @@ class FileOutputStream extends OutputStream {
      * @throws IOException - if unable to open file.
      */
     public function __construct($file, $append = false) {
+        global $php_errormsg;
         if ($file instanceof PhingFile) {
             $this->file = $file;
         } elseif (is_string($file)) {


### PR DESCRIPTION
Fix for:
[Notice] Undefined variable: php_errormsg (@line 58 in file phing/classes/phing/system/io/FileOutputStream.php).
