### PR TITLE
Make imported targets available as importname.targetname

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -913,7 +913,7 @@ class Phing {
 
             // subtargets are targets w/o descriptions
             if ($targetDescription === null) {
-                $subNames[] = $targetName;
+                $subNames[$targetName] = $targetName;
             } else {
                 // topNames and topDescriptions are handled later
                 // here we store in hash map (for sorting purposes)

--- a/classes/phing/parser/ProjectConfigurator.php
+++ b/classes/phing/parser/ProjectConfigurator.php
@@ -47,9 +47,6 @@ class ProjectConfigurator {
     public $buildFile;
     public $buildFileParent;
 
-    /** Targets in current file */
-    private $currentTargets;
-
     /** Synthetic target that will be called at the end to the parse phase */
     private $parseEndTarget;
 
@@ -140,10 +137,6 @@ class ProjectConfigurator {
      */
     public function setIgnoreProjectTag($flag) {
         $this->ignoreProjectTag = $flag;
-    }
-
-    public function &getCurrentTargets () {
-      return $this->currentTargets;
     }
 
     public function isParsing () {

--- a/classes/phing/parser/ProjectHandler.php
+++ b/classes/phing/parser/ProjectHandler.php
@@ -92,15 +92,31 @@ class ProjectHandler extends AbstractHandler {
                 throw new ExpatParseException("Unexpected attribute '$key'");
             }
         }
+        
         // these things get done no matter what
+        $resolvedBasedir = null;
+               if ($baseDir === null) {
+                       $resolvedBasedir = $buildFileParent->getAbsolutePath();
+               } else {
+                       // check whether the user has specified an absolute path
+                       $f = new PhingFile($baseDir);
+                       if ($f->isAbsolute()) {
+                               $resolvedBasedir = $baseDir;
+                       } else {
+                               $resolvedBasedir = $project->resolveFile($baseDir, $buildFileParent);
+                       }
+               }
+        
         if (null != $name) {
             $canonicalName = self::canonicalName($name);
             $this->configurator->setCurrentProjectName($canonicalName);
             $path = (string) $this->configurator->getBuildFile(); 
             $project->setUserProperty("phing.file.{$canonicalName}", $path);
             $project->setUserProperty("phing.dir.{$canonicalName}",  dirname($path));
+            $project->setUserProperty("project.basedir.{$canonicalName}", $resolvedBasedir);
         }
 
+               // this only happens for toplevel build files
         if (!$this->configurator->isIgnoringProjectTag()) {
           if ($def === null) {
             throw new ExpatParseException(
@@ -126,21 +142,12 @@ class ProjectHandler extends AbstractHandler {
               $project->setPhingVersion($ver);
           }
 
-          if ($project->getProperty("project.basedir") !== null) {
-            $project->setBasedir($project->getProperty("project.basedir"));
+          if (($bd = $project->getProperty("project.basedir")) !== null) {
+              $project->setBasedir($bd);
           } else {
-            if ($baseDir === null) {
-              $project->setBasedir($buildFileParent->getAbsolutePath());
-            } else {
-              // check whether the user has specified an absolute path
-              $f = new PhingFile($baseDir);
-              if ($f->isAbsolute()) {
-                $project->setBasedir($baseDir);
-              } else {
-                $project->setBaseDir($project->resolveFile($baseDir, new PhingFile(getcwd())));
-              }
-            }
+              $project->setBasedir($resolvedBasedir);
           }
+                          
         }
     }
 

--- a/classes/phing/parser/TargetHandler.php
+++ b/classes/phing/parser/TargetHandler.php
@@ -110,12 +110,10 @@ class TargetHandler extends AbstractHandler {
 
         // shorthand
         $project = $this->configurator->project;
-
-        // check to see if this target is a dup within the same file
-        if (isset($this->configurator->getCurrentTargets[$name])) {
-          throw new BuildException("Duplicate target: $targetName",  
-              $this->parser->getLocation());
-        }
+        $projectTargets = $project->getTargets();
+        $currentProjectName = $this->configurator->getCurrentProjectName();
+        $importedFile = $this->configurator->isIgnoringProjectTag(); 
+        $targetAdded = false;
 
         $this->target = new Target();
         $this->target->setName($name);
@@ -128,37 +126,36 @@ class TargetHandler extends AbstractHandler {
             $this->target->setDepends($depends);
         }
 
-        $usedTarget = false;
-        // check to see if target with same name is already defined
-        $projectTargets = $project->getTargets();
         if (isset($projectTargets[$name])) {
-          $project->log("Already defined in main or a previous import, " .
-            "ignore {$name}", Project::MSG_VERBOSE);
+               if (!$importedFile) 
+                               throw new BuildException("Duplicate target: $name", $this->parser->getLocation());
+                       else
+                               $project->log("Target $name already defined, either in main or a previous import. Not importing it under this name.", Project::MSG_VERBOSE);
         } else {
           $project->addTarget($name, $this->target);
-          if ($id !== null && $id !== "") {
-            $project->addReference($id, $this->target);
-          }
-          $usedTarget = true;
+               $targetAdded = true;
         }
 
-        if ($this->configurator->isIgnoringProjectTag() && 
-            $this->configurator->getCurrentProjectName() != null && 
-            strlen($this->configurator->getCurrentProjectName()) != 0) {
-          // In an impored file (and not completely
-          // ignoring the project tag)
-          $newName = $this->configurator->getCurrentProjectName() . "." . $name;
-          if ($usedTarget) {
-            // clone needs to make target->children a shared reference
-            $newTarget = clone $this->target;
-          } else {
-            $newTarget = $this->target;
+        // If we're in an imported file and the project name is set, 
+               // we can namespace the target. If we're imported but have no
+               // project name and the target name is taken, silently ignore the new (imported) target.
+        if ($importedFile && $currentProjectName) {
+                       $namespacedName = "$currentProjectName.$name";
+
+               if (!isset($projectTargets[$namespacedName])) {
+
+                       if (!$targetAdded)
+                       $this->target->setName($namespacedName);
+                 
+                       $project->log("Adding $name as $namespacedName.", Project::MSG_DEBUG);
+                       $project->addTarget($namespacedName, $this->target);
+                       $targetAdded = true;
           }
-          $newTarget->setName($newName);
-          $ct = $this->configurator->getCurrentTargets();
-          $ct[$newName] = $newTarget;
-          $project->addTarget($newName, $newTarget);
         }
+        
+               if ($targetAdded && $id) 
+               $project->addReference($id, $this->target);
+        
     }
 
     /**

--- a/docs/docbook5/en/source/appendixes/coretasks.xml
+++ b/docs/docbook5/en/source/appendixes/coretasks.xml
@@ -1795,9 +1795,10 @@
 	<sect1 role="taskdef" xml:id="ImportTask">
 		<title>ImportTask </title>
 		<para>Imports another build file into the current project.</para>
-		<para>On execution it will read another Phing file into the same Project. Functionally it is
-			nearly the same as copy and pasting the imported file onto the end of the importing
-			file.</para>
+        <para>
+            On execution it will read another Phing file into the same Project. Functionally it is nearly the same as
+            copy and pasting the imported file onto the end of the importing file.
+        </para>
 		<table>
 			<title>Attributes</title>
 			<tgroup cols="5">
@@ -1835,67 +1836,119 @@
 		</table>
 		<sect2>
 			<title>Target Overriding</title>
-			<para>If a target in the main file is also present in at least one of the imported
-				files, the one from the main file takes precedence.</para>
-			<para>So if I import for example a <literal>docs/build.xml</literal> file named
-					<filename>builddocs</filename>, that contains a "<literal>docs</literal>"
-				target, I can redefine it in my main buildfile and that is the one that will be
-				called. This makes it easy to keep the same target name, so that the overriding
-				target is still called by any other targets--in either the main or imported
-				buildfile(s)--for which it is a dependency, with a different implementation. The
-				target from <literal>docs/build.xml</literal> is made available by the name
-					"<literal>builddocs.docs</literal>". This enables the new implementation to call
-				the old target, thus enhancing it with tasks called before or after it.</para>
+			<para>If a target in the main file is also present in at least one of the imported files, the one from the
+				main file takes precedence.
+			</para>
+			<para>So if I import for example a
+				<literal>docs/build.xml</literal>
+				file named
+				<filename>builddocs</filename>, that contains a "<literal>docs</literal>" target, I can redefine
+				"<literal>docs</literal>" in my main buildfile and that is the one that will be called. This makes
+				it easy to keep the same target name, so that the overriding target is still called by any other
+				targets -- in either the main or imported buildfile(s) -- for which it is a dependency,
+				with a different implementation.
+			</para>
 		</sect2>
+
 		<sect2>
 			<title>Special Properties</title>
-			<para>Imported files are treated as they are present in the main buildfile. This makes
-				it easy to understand, but it makes it impossible for them to reference files and
-				resources relative to their path. Because of this, for every imported file, Phing
-				adds a property that contains the path to the imported buildfile. With this path,
-				the imported buildfile can keep resources and be able to reference them relative to
-				its position.</para>
-			<para>So if I import for example a <literal>docs/build.xml</literal> file named
-					<filename>builddocs</filename>, I can get its path as
-					<literal>phing.file.builddocs</literal>, similarly to the
-					<literal>phing.file</literal> property of the main buildfile. Additionally,
-					the directory will be stored in <literal>phing.dir.builddocs</literal>.</para>
-			<para>Note that "builddocs" is not the filename, but the name attribute present in the
-				imported project tag.</para>
-			<para>If import file does not have a name attribute, the
-					<literal>phing.file.projectname</literal> and <literal>phing.dir.projectname</literal>
-					properties will not be set.</para>
+
+			<para>
+				Imported files are treated as if they were present in the main buildfile. However, this means
+				that properties like
+				<literal>phing.file</literal>
+				and
+				<literal>project.basedir</literal>
+				take
+				values according to the main build file. Especially with "reusable" build logic that get imported
+				into a lot of different files, this might not be what you want.
+			</para>
+
+			<para>
+				To make it possible for imported files to reference files and resources relative to their own location,
+				Phing adds the following properties, where
+				<emphasis>projectname</emphasis>
+				is the name attribute
+				present in the imported file's
+				<literal>&lt;project&gt;</literal>
+				tag:
+			</para>
+
+			<itemizedlist>
+				<listitem>
+					<literal>project.basedir.
+						<emphasis>projectname</emphasis>
+					</literal>
+					: The imported project's basedir as determined by the basedir attribute from the imported file.
+				</listitem>
+				<listitem>
+					<literal>phing.file.
+						<emphasis>projectname</emphasis>
+					</literal>
+					: The path to the imported build file.
+				</listitem>
+				<listitem>
+					<literal>phing.dir.
+						<emphasis>projectname</emphasis>
+					</literal>
+					: The directory containing the imported build file.
+				</listitem>
+			</itemizedlist>
+
+			<para>
+				If the imported file does not have a name attribute, these properties will not be set.
+			</para>
+
 		</sect2>
+
+
 		<sect2>
 			<title>Resolving Files Against the Imported File</title>
-			<para>Suppose your main build file called <literal>importing.xml</literal> imports a
-				build file <filename>imported.xml</filename> , located anywhere on the file system,
-				and <literal>imported.xml</literal> reads a set of properties from
-					<literal>imported.properties</literal> :</para>
-			<programlisting language="xml">&lt;!-- importing.xml -->
-&lt;project name="importing" basedir="." default="...">
-  &lt;import file="${path_to_imported}/imported.xml"/>
-&lt;/project>
 
-&lt;!-- imported.xml -->
-&lt;project name="imported" basedir="." default="...">
-  &lt;property file="imported.properties"/>
-&lt;/project></programlisting>
-			<para>This snippet however will resolve <literal>imported.properties</literal> against
-				the basedir of <literal>importing.xml</literal> , because the basedir of
-					<literal>imported.xml</literal> is ignored by Phing. The right way to use
-					<literal>imported.properties</literal> is:</para>
-			<programlisting language="xml">&lt;!-- imported.xml -->
-&lt;project name="imported" basedir="." default="...">
-  &lt;property file="${phing.file.imported}/imported.properties"/>
-&lt;/project></programlisting>
-			<para>As explained above <literal>${phing.file.imported}</literal> stores the full path of the build
-				script, that defines the project called <emphasis>imported</emphasis>, (in short it
-				stores the path to <literal>imported.xml</literal>) and <literal>${phing.dir.imported}</literal>
-				stores its directory. This technique also allows
-					<literal>imported.xml</literal> to be used as a standalone file (without being
-				imported in other project).</para>
+			<para>
+				As an example, suppose your main build file called
+				<filename>importing.xml</filename>
+				imports a build file
+				<filename>imported.xml</filename>, located anywhere on the file system, and
+				<filename>imported.xml</filename>
+				reads a set of properties from<filename>imported.properties</filename>:
+			</para>
 
+			<programlisting language="xml"><![CDATA[
+				<!-- importing.xml -->
+				<project name="importing" basedir="." default="...">
+				  <import file="${path_to_imported}/imported.xml"/>
+				</project>
+
+				<!-- imported.xml -->
+				<project name="imported" basedir="." default="...">
+				  <property file="imported.properties"/>
+				</project>
+			]]></programlisting>
+
+			<para>
+				Because of the way the ImportTask works, this will resolve
+				<filename>imported.properties</filename>
+				against the
+				basedir of
+				<filename>importing.xml</filename>, not that of<filename>imported.xml</filename>.
+				The right way to use
+				<filename>imported.properties</filename>
+				is:
+			</para>
+
+			<programlisting language="xml"><![CDATA[
+<!-- imported.xml -->
+<project name="imported" basedir="." default="...">
+  <property file="${project.basedir.imported}/imported.properties"/>
+</project>
+			]]></programlisting>
+
+			<para>
+				This technique also allows
+				<filename>imported.xml</filename>
+				to be used as a standalone file (without being imported in other project).
+			</para>
 		</sect2>
 
 		<sect2>

--- a/docs/docbook5/en/source/appendixes/factsheet.xml
+++ b/docs/docbook5/en/source/appendixes/factsheet.xml
@@ -81,6 +81,14 @@
                         <entry>Path that contains the current buildfile.</entry>
                     </row>
                     <row>
+                        <entry><literal>phing.file.<emphasis>projectname</emphasis></literal></entry>
+                        <entry>Full path to an imported buildfile containing the project named <emphasis>projectname</emphasis>.</entry>
+                    </row>
+                    <row>
+                        <entry><literal>phing.dir.<emphasis>projectname</emphasis></literal></entry>
+                        <entry>Path that contains the imported buildfile for the project named <emphasis>projectname</emphasis>.</entry>
+                    </row>
+                    <row>
                         <entry><literal>phing.home</literal></entry>
                         <entry>Phing installation directory, not set in PEAR installations.</entry>
                     </row>

--- a/docs/phing_guide/book/chapters/appendixes/AppendixA-FactSheet.html
+++ b/docs/phing_guide/book/chapters/appendixes/AppendixA-FactSheet.html
@@ -101,6 +101,14 @@
 				<td>Path that contains the current buildfile.</td>
 			</tr>
 			<tr>
+				<td>phing.file.<em>projectname</em></td>
+				<td>Full path to an imported buildfile containing the project named <em>projectname</em>.</td>
+			</tr>
+			<tr>
+				<td>phing.dir.<em>projectname</em></td>
+				<td>Path that contains the imported buildfile for the project named <em>projectname</em>.</td>
+			</tr>
+			<tr>
 				<td>phing.home</td>
 				<td>Phing installation directory, not set in <em>PEAR</em>
 					installations.</td>
@@ -132,6 +140,10 @@
 			</tr>
 
 			<tr>
+                               <td>project.basedir.<em>projectname</em></td>
+                               <td>For an imported project named <em>projectname</em>, the directory qualified by the imported file's basedir attribute.</td>
+                       </tr>
+                       <tr>
 				<td>user.home</td>
 				<td>Value of the environment variable <em>HOME</em>.</td>
 			</tr>

--- a/docs/phing_guide/book/chapters/appendixes/AppendixB-CoreTasks.html
+++ b/docs/phing_guide/book/chapters/appendixes/AppendixB-CoreTasks.html
@@ -1277,45 +1277,67 @@
  &lt;/else&gt;
 &lt;/if&gt;
 </pre>
-		<h2>
-			<a name="ImportTask"></a>ImportTask </h2>
-		<p>Imports another build file into the current project.</p>
-		<p>On execution it will read another Phing file into the same Project. Functionally it is
-			nearly the same as copy and pasting the imported file onto the end of the importing
-			file.</p>
-		<h3>Target Overriding</h3>
-		<p>If a target in the main file is also present in at least one of the imported files, the
-			one from the main file takes precedence.</p>
-		<p> So if I import for example a <em>docs/build.xml</em> file named
-				<strong>builddocs</strong>, that contains a "<strong>docs</strong>" target, I can
-			redefine it in my main buildfile and that is the one that will be called. This makes it
-			easy to keep the same target name, so that the overriding target is still called by any
-			other targets--in either the main or imported buildfile(s)--for which it is a
-			dependency, with a different implementation. The target from <em>docs/build.xml</em> is
-			made available by the name "<strong>builddocs.docs</strong>". This enables the new
-			implementation to call the old target, thus enhancing it with tasks called before or
-			after it. </p>
-		<h3>Special Properties</h3>
-		<p>Imported files are treated as they are present in the main buildfile. This makes it easy
-			to understand, but it makes it impossible for them to reference files and resources
-			relative to their path. Because of this, for every imported file, Phing adds a property
-			that contains the path to the imported buildfile. With this path, the imported buildfile
-			can keep resources and be able to reference them relative to its position.</p>
-		<p> So if I import for example a <em>docs/build.xml</em> file named
-				<strong>builddocs</strong>, I can get its path as
-				<strong>phing.file.builddocs</strong>, similarly to the <strong>phing.file</strong>
-			property of the main buildfile. Additionally, the directory will be stored in 
-			<strong>phing.dir.builddocs</strong>.</p>
-		<p>Note that "builddocs" is not the filename, but the name attribute present in the imported
-			project tag.</p>
-		<p>If import file does not have a name attribute, the <strong>phing.file.projectname</strong>
-		    and <strong>phing.dir.projectname</strong> properties will not be set.</p>
-		<h3>Resolving Files Against the Imported File</h3>
-		<p> Suppose your main build file called <code>importing.xml</code> imports a build file
-				<code>imported.xml</code> , located anywhere on the file system, and
-				<code>imported.xml</code> reads a set of properties from
-				<code>imported.properties</code> : </p>
-		<pre>
+	<h2>
+		<a name="ImportTask"></a>ImportTask
+	</h2>
+	<p>Imports another build file into the current project.</p>
+	<p>On execution it will read another Phing file into the same
+		Project. Functionally it is nearly the same as copy and pasting the
+		imported file onto the end of the importing file.</p>
+	<h3>Target Overriding</h3>
+	<p>If a target in the main file is also present in at least one of
+		the imported files, the one from the main file takes precedence.</p>
+
+	<p>
+		So if I import for example a <em>docs/build.xml</em> file named <strong>builddocs</strong>,
+               that contains a "<strong>docs</strong>" target, I can redefine "<strong>docs</strong>" in
+		my main buildfile and that is the one that will be called. This makes
+		it easy to keep the same target name, so that the overriding target is
+		still called by any other targets--in either the main or imported
+		buildfile(s)--for which it is a dependency, with a different
+               implementation.</p>
+
+       <h3>Target "namespacing"</h3>
+               <p>A target defined in an imported file will always be available under the
+               name <strong>importName</strong>.<strong>targetName</strong>.</p> 
+
+                <p>Considering the previous example, the target <strong>docs</strong> from <em>docs/build.xml</em> will always
+               be available by the name "<strong>builddocs.docs</strong>". This enables
+		the new implementation to call the old target, thus enhancing it with
+               tasks called before or after it. On the other hand, by calling <strong>builddocs.docs</strong>
+               from <em>docs/build.xml</em>, targets from the <strong>builddocs</strong> file can be sure 
+               to call "their" implementation.</p>
+
+	<h3>Special Properties</h3>
+       <p>Imported files are treated as if they were present in the main
+               buildfile. However, this means that properties like <strong>phing.file</strong> and 
+               <strong>project.basedir</strong> take values according to the main build file. Especially
+               with "reusable" build logic that get imported into a lot of different files, this might not 
+               be what you want.</p>
+
+       <p>To make it possible for imported files to reference files and resources relative to their own
+       location, Phing adds the following properties, where <em>projectname</em> is the name attribute
+       present in the imported file's <code>&lt;project&gt;</code> tag:</p>
+       <ul>
+       <li><strong>project.basedir.<em>projectname</em></strong>: The imported project's basedir as determined by the basedir attribute
+       from the imported file.</li>
+       <li><strong>phing.file.<em>projectname</em></strong>: The path to the imported build file.</li>
+	   <li><strong>phing.dir.<em>projectname</em></strong>: The directory containing the imported build file.</li>
+       </ul>
+
+       <p>If the imported file does not have a name attribute, these properties will not be set.</p>
+
+       <p>As an example, 
+               suppose your main build file called
+		<code>importing.xml</code>
+		imports a build file
+		<code>imported.xml</code>, located anywhere on the file system, and
+		<code>imported.xml</code>
+		reads a set of properties from
+		<code>imported.properties</code>
+		:
+	</p>
+	<pre>
 &lt;!-- importing.xml --&gt;
 &lt;project name=&quot;importing&quot; basedir=&quot;.&quot; default=&quot;...&quot;&gt;
   &lt;import file=&quot;${path_to_imported}/imported.xml&quot;/&gt;
@@ -1326,22 +1348,27 @@
   &lt;property file=&quot;imported.properties&quot;/&gt;
 &lt;/project&gt;
 </pre>
-		<p> This snippet however will resolve <code>imported.properties</code> against the basedir
-			of <code>importing.xml</code> , because the basedir of <code>imported.xml</code> is
-			ignored by Phing. The right way to use <code>imported.properties</code> is: </p>
-		<pre>
+	<p>
+               Because of the way the ImportTask works, this will resolve
+		<code>imported.properties</code>
+		against the basedir of
+               <code>importing.xml</code>, not that of <code>imported.xml</code>. The right way to use
+		<code>imported.properties</code>
+		is:
+	</p>
+	<pre>
 &lt;!-- imported.xml --&gt;
 &lt;project name=&quot;imported&quot; basedir=&quot;.&quot; default=&quot;...&quot;&gt;
-  &lt;property file=&quot;${phing.dir.imported}/imported.properties&quot;/&gt;
+  &lt;property file=&quot;${project.basedir.imported}/imported.properties&quot;/&gt;
 &lt;/project&gt;
 </pre>
-		<p> As explained above <code>${phing.file.imported}</code> stores the full path of the build
-			script, that defines the project called <strong>imported</strong>, (in short it stores
-			the path to <em>imported.xml</em>) and <code>${phing.dir.imported}</code> stores its
-			directory. This technique also allows <em>imported.xml</em> to be used as a standalone
-			file (without being imported in other project). </p>
-		<h3>Example</h3>
-		<pre>
+	<p>
+                This technique also allows
+		<em>imported.xml</em> to be used as a standalone file (without being
+		imported in other project).
+	</p>
+	<h3>Example</h3>
+	<pre>
 &lt;import file=&quot;path/to/build.xml&quot;/&gt;
 &lt;import file=&quot;path/to/build.xml&quot; optional=&quot;true&quot;/&gt;
 </pre>


### PR DESCRIPTION
Also add properties to access imported files' path and directory.

See ticket #620 (http://www.phing.info/trac/ticket/620); this cherry-picks dd97b791d6527a6f9e2fd13f50327cc2cd990dd8 off unstable-3.0.