### PR TITLE
Replaced phpcs --version by PHP_CodeSniffer::VERSION in version check to improve Composer compatibility.

### DIFF
--- a/classes/phing/tasks/ext/PhpCodeSnifferTask.php
+++ b/classes/phing/tasks/ext/PhpCodeSnifferTask.php
@@ -327,7 +327,7 @@ class PhpCodeSnifferTask extends Task {
          * Determine PHP_CodeSniffer version number
          */
         if (!$this->skipversioncheck) {
-            preg_match('/\d\.\d\.\d/', shell_exec('phpcs --version'), $version);
+            preg_match('/\d\.\d\.\d/', PHP_CodeSniffer::VERSION, $version);
 
             if (version_compare($version[0], '1.2.2') < 0) {
                 throw new BuildException(


### PR DESCRIPTION
Composer users are not able to use `PhpCodeSnifferTask` without `skipversioncheck="true"` because `phpcs` is not on system's path by default, so `version_compare` always fails. However, we can use Composer-agnostic `PHP_CodeSniffer::VERSION` const, so that's what I did.
