### PR TITLE
Ticket #1056

### DIFF
--- a/classes/phing/tasks/ext/FileSyncTask.php
+++ b/classes/phing/tasks/ext/FileSyncTask.php
@@ -253,11 +253,11 @@ class FileSyncTask extends Task
         }
         
         if ($this->verbose === true) {
-            $options .= 'v';
+            $options .= ' --verbose';
         }
         
         if ($this->checksum === true) {
-            $options .= 'c';
+            $options .= ' --checksum';
         }
         
         if ($this->identityFile !== null) {


### PR DESCRIPTION
fixing problem with attaching "v" (verbose) option to the end of "options" string + additinally "c" (checksum) option as well. Details on ticket page http://www.phing.info/trac/ticket/1056
