### PR TITLE
forceExtract behaviour does not work when extract without a fileset

### DIFF
--- a/classes/phing/tasks/ext/ExtractBaseTask.php
+++ b/classes/phing/tasks/ext/ExtractBaseTask.php
@@ -97,7 +97,7 @@ abstract class ExtractBaseTask extends MatchingTask {
         
         $filesToExtract = array();
         if ($this->file !== null) {
-            if(!$this->isDestinationUpToDate($this->file)) {
+            if($this->forceExtract || !$this->isDestinationUpToDate($this->file)) {
                 $filesToExtract[] = $this->file;
             } else {
                 $this->log('Nothing to do: ' . $this->todir->getAbsolutePath() . ' is up to date for ' .  $this->file->getCanonicalPath(), Project::MSG_INFO);


### PR DESCRIPTION
The "forceExtract" attribute is not used when the extracted file is given only with the "file" attribute, so use this attribute just do nothing in this case...

I just add the test on "forceExtract" attribute when "file" attribute is checked before adding to extraction list...
