### PR TITLE
Fix composer support in PHPCPDTask.

### DIFF
--- a/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
+++ b/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
@@ -194,7 +194,7 @@ class PHPCPDTask extends Task
      */
     public function main()
     {
-        if (class_exists('Composer\\Autoloader\\ClassLoader', false)) {
+        if (class_exists('\\Composer\\Autoload\\ClassLoader', false)) {
             if (!class_exists('\\SebastianBergmann\\PHPCPD\\Detector\\Detector')) {
                 throw new BuildException('You need to install PHPCPD or add your include path to your composer installation.');
             }


### PR DESCRIPTION
Composer's ClassLoader is actually called \Composer\Autoload\ClassLoader.
