### PR TITLE
Consider the strings "1" and "0" to be true and false, respectively.

### DIFF
--- a/classes/phing/util/StringHelper.php
+++ b/classes/phing/util/StringHelper.php
@@ -12,8 +12,8 @@
  */
 class StringHelper {
 
-    private static $TRUE_VALUES = array("on", "true", "t", "yes");
-    private static $FALSE_VALUES = array("off", "false", "f", "no");
+    private static $TRUE_VALUES = array("on", "true", "t", "yes", "1");
+    private static $FALSE_VALUES = array("off", "false", "f", "no", "0");
     
     /**
      * Replaces identifier tokens with corresponding text values in passed string.


### PR DESCRIPTION
Somewhere along a build process PHP has written a boolean `true` to a property file as the string `"1"`. It would be of great benefit to me if the strings "1" and "0" could be recognized as boolean values by StringHelper.

This is just a suggestion, I haven't investigated it's potential effects but it seems harmless to me.
