### PR TITLE
Fix unset error output stream

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -205,7 +205,7 @@ class Phing {
         }
         if (self::$err === null) {
             if (!defined('STDERR')) {
-              self::$out = new OutputStream(fopen('php://stderr', 'w'));
+              self::$err = new OutputStream(fopen('php://stderr', 'w'));
             } else {
               self::$err = new OutputStream(STDERR);
             }


### PR DESCRIPTION
This change fixed the below error I got:
Catchable fatal error:  Argument 2 passed to DefaultLogger::printMessage() must be an instance of OutputStream, null given, called in C:\xampp\htdocs\valid4life\deploy\vendor\phing\phing\classes\phing\listener\DefaultLogger.php on line 244 and defined in C:\xampp\htdocs\valid4life\deploy\vendor\phing\phing\classes\phing\listener\DefaultLogger.php on line 277
