### PR TITLE
enable phar writing when running phing

### DIFF
--- a/bin/pear-phing
+++ b/bin/pear-phing
@@ -15,4 +15,4 @@ if (test -z "$PHP_COMMAND") ; then
 	export PHP_COMMAND
 fi
 
-$PHP_COMMAND -d html_errors=off -qC @PEAR-DIR@/phing.php -logger phing.listener.AnsiColorLogger "$@"
+$PHP_COMMAND -d phar.readonly=off -d html_errors=off -qC @PEAR-DIR@/phing.php -logger phing.listener.AnsiColorLogger "$@"

--- a/bin/phing.bat
+++ b/bin/phing.bat
@@ -33,7 +33,7 @@ goto run
 goto cleanup
 
 :run
-"%PHP_COMMAND%" -d html_errors=off -qC "%PHING_HOME%\bin\phing.php" %*
+"%PHP_COMMAND%" -d phar.readonly=off -d html_errors=off -qC "%PHING_HOME%\bin\phing.php" %*
 goto cleanup
 
 :no_phpcommand


### PR DESCRIPTION
By default, PHP applications may not modify phar archives
because php.ini defines phar.readonly=1.

The phing wrapper script now sets phar.readonly=0 via
a commandline parameter to PHP, so that <pharpackage>
can properly write .phar files.
