### PR TITLE
Followup of #1090: Prevent notice when baseinstalldir is not set

### DIFF
--- a/classes/phing/util/PearPackageScanner.php
+++ b/classes/phing/util/PearPackageScanner.php
@@ -223,7 +223,9 @@ class PearPackageScanner extends DirectoryScanner
                 continue;
             }
             $origFile = $file;
-            $file = ltrim($att['baseinstalldir'] . '/' . $file, '/');
+            if (isset($att['baseinstalldir'])) {
+                $file = ltrim($att['baseinstalldir'] . '/' . $file, '/');
+            }
             $file = str_replace('/', DIRECTORY_SEPARATOR, $file);
 
             if ($this->isIncluded($file)) {


### PR DESCRIPTION
.. in PearPackageFileSet
