### PR TITLE
Optionally wrap DbDeploy deltas in transactions

### DIFF
--- a/classes/phing/tasks/ext/dbdeploy/DbDeployTask.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbDeployTask.php
@@ -241,8 +241,6 @@ class DbDeployTask extends Task
      */
     protected function generateSql($undo = false)
     {
-        echo 'narf';
-
         $sql = '';
         $lastChangeAppliedInDb = $this->getLastChangeAppliedInDb();
         $files = $this->getDeltasFilesArray();

--- a/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxMsSql.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxMsSql.php
@@ -18,7 +18,7 @@
  * and is licensed under the LGPL. For more information please see
  * <http://phing.info>.
  */
- 
+
 /**
  * Utility class for generating necessary server-specific SQL commands
  *
@@ -26,11 +26,21 @@
  * @version  $Id$
  * @package  phing.tasks.ext.dbdeploy
  */
-class DbmsSyntaxMsSql extends DbmsSyntax 
+class DbmsSyntaxMsSql extends DbmsSyntax
 {
     public function generateTimestamp()
     {
         return "DATEDIFF(s, '19700101', GETDATE())";
+    }
+
+    public function beginTransaction()
+    {
+        return 'BEGIN TRANSACTION;';
+    }
+
+    public function commitTransaction()
+    {
+        return 'COMMIT;';
     }
 }
 

--- a/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxMysql.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxMysql.php
@@ -18,7 +18,7 @@
  * and is licensed under the LGPL. For more information please see
  * <http://phing.info>.
  */
- 
+
 /**
  * Utility class for generating necessary server-specific SQL commands
  *
@@ -26,11 +26,21 @@
  * @version  $Id$
  * @package  phing.tasks.ext.dbdeploy
  */
-class DbmsSyntaxMysql extends DbmsSyntax 
+class DbmsSyntaxMysql extends DbmsSyntax
 {
     public function generateTimestamp()
     {
         return "NOW()";
+    }
+
+    public function beginTransaction()
+    {
+        return 'START TRANSACTION;';
+    }
+
+    public function commitTransaction()
+    {
+        return 'COMMIT;';
     }
 }
 

--- a/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxOracle.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxOracle.php
@@ -18,7 +18,7 @@
  * and is licensed under the LGPL. For more information please see
  * <http://phing.info>.
  */
- 
+
 /**
  * Utility class for generating necessary server-specific SQL commands
  *
@@ -26,16 +26,26 @@
  * @version  $Id$
  * @package  phing.tasks.ext.dbdeploy
  */
-class DbmsSyntaxOracle extends DbmsSyntax 
+class DbmsSyntaxOracle extends DbmsSyntax
 {
     public function applyAttributes($db)
     {
         $db->setAttribute(PDO::ATTR_CASE, PDO::CASE_LOWER);
     }
-    
+
     public function generateTimestamp()
     {
         return "(sysdate - to_date('01-JAN-1970','DD-MON-YYYY')) * (86400)";
+    }
+
+    public function beginTransaction()
+    {
+        return 'START TRANSACTION;';
+    }
+
+    public function commitTransaction()
+    {
+        return 'COMMIT;';
     }
 }
 

--- a/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxPgSQL.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxPgSQL.php
@@ -18,7 +18,7 @@
  * and is licensed under the LGPL. For more information please see
  * <http://phing.info>.
  */
- 
+
 /**
  * Utility class for generating necessary server-specific SQL commands
  *
@@ -26,11 +26,21 @@
  * @version  $Id$
  * @package  phing.tasks.ext.dbdeploy
  */
-class DbmsSyntaxPgSQL extends DbmsSyntax 
+class DbmsSyntaxPgSQL extends DbmsSyntax
 {
     public function generateTimestamp()
     {
         return "NOW()";
+    }
+
+    public function beginTransaction()
+    {
+        return 'BEGIN;';
+    }
+
+    public function commitTransaction()
+    {
+        return 'COMMIT;';
     }
 }
 

--- a/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxSQLite.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxSQLite.php
@@ -18,7 +18,7 @@
  * and is licensed under the LGPL. For more information please see
  * <http://phing.info>.
  */
- 
+
 /**
  * Utility class for generating necessary server-specific SQL commands
  *
@@ -26,11 +26,21 @@
  * @version  $Id$
  * @package  phing.tasks.ext.dbdeploy
  */
-class DbmsSyntaxSQLite extends DbmsSyntax 
+class DbmsSyntaxSQLite extends DbmsSyntax
 {
     public function generateTimestamp()
     {
         return "strftime('%s','now')";
+    }
+
+    public function beginTransaction()
+    {
+        return 'BEGIN TRANSACTION;';
+    }
+
+    public function commitTransaction()
+    {
+        return 'COMMIT;';
     }
 }
 


### PR DESCRIPTION
After wondering for a while now why the phing task does not wrap delta scripts in transactions (as it reads on the DbDeploy homepage) I added the functionality the the task. 

```
    <dbdeploy transactional="true" />
```

it is now a new configuration option on the task.
