### PR TITLE
AutoloaderTask

### DIFF
--- a/classes/phing/tasks/defaults.properties
+++ b/classes/phing/tasks/defaults.properties
@@ -141,6 +141,7 @@ apigen=phing.tasks.ext.apigen.ApiGenTask
 parallel=phing.tasks.ext.ParallelTask
 symfonyconsole=phing.tasks.ext.SymfonyConsole.SymfonyConsoleTask
 composer=phing.tasks.ext.ComposerTask
+autoloader=phing.tasks.ext.AutoloaderTask
 ; liquibase
 liquibase-changelog=phing.tasks.ext.liquibase.LiquibaseChangeLogTask
 liquibase-dbdoc=phing.tasks.ext.liquibase.LiquibaseDbDocTask

--- a/classes/phing/tasks/ext/AutoloaderTask.php
+++ b/classes/phing/tasks/ext/AutoloaderTask.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+require_once "phing/Task.php";
+
+/**
+ * @author Max Romanovsky <max.romanovsky@gmail.com>
+ * @package phing.tasks.ext
+ */
+class AutoloaderTask extends Task {
+
+    const DEFAULT_AUTOLOAD_PATH = 'vendor/autoload.php';
+
+    private $autoloaderPath = self::DEFAULT_AUTOLOAD_PATH;
+
+    /**
+     * @return string
+     */
+    public function getAutoloaderPath()
+    {
+        return $this->autoloaderPath;
+    }
+
+    /**
+     * @param string $autoloaderPath
+     */
+    public function setAutoloaderPath($autoloaderPath)
+    {
+        $this->autoloaderPath = $autoloaderPath;
+    }
+
+    /**
+     *  Called by the project to let the task do it's work. This method may be
+     *  called more than once, if the task is invoked more than once. For
+     *  example, if target1 and target2 both depend on target3, then running
+     *  <em>phing target1 target2</em> will run all tasks in target3 twice.
+     *
+     *  Should throw a BuildException if someting goes wrong with the build
+     *
+     *  This is here. Must be overloaded by real tasks.
+     */
+    public function main()
+    {
+        if (is_dir($this->autoloaderPath) || !is_readable($this->autoloaderPath)) {
+            throw new BuildException(sprintf('Provided autoloader file "%s" is not a readable file', $this->autoloaderPath));
+        }
+        $this->log('Loading autoloader from ' . $this->autoloaderPath);
+        require_once $this->autoloaderPath;
+    }
+
+}

--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -263,6 +263,45 @@
   todo="true"/></programlisting>
         </sect2>
     </sect1>
+    <sect1 role="taskdef" xml:id="AutoloaderTask">
+        <title>AutoloaderTask</title>
+        <para>
+            The AutoloaderTask includes autoload file to bootstrap all necessary components in Phing execution context.
+            It could be useful if build tools (e.g. phpunit, phploc etc.) are installed as Composer dependencies.
+        </para>
+        <table>
+            <title>Attributes</title>
+            <tgroup cols="5">
+                <colspec colname="name" colnum="1" colwidth="1.5*"/>
+                <colspec colname="type" colnum="2" colwidth="0.8*"/>
+                <colspec colname="description" colnum="3" colwidth="3.5*"/>
+                <colspec colname="default" colnum="4" colwidth="0.8*"/>
+                <colspec colname="required" colnum="5" colwidth="1.2*"/>
+                <thead>
+                    <row>
+                        <entry>Name</entry>
+                        <entry>Type</entry>
+                        <entry>Description</entry>
+                        <entry>Default</entry>
+                        <entry>Required</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry><literal>autoloaderpath</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Path to autoloader file</entry>
+                        <entry>vendor/autoload.php</entry>
+                        <entry>Yes</entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+        <sect2>
+            <title>Example</title>
+            <programlisting language="xml">&lt;autoloader autoloaderpath="foo/autoload.php"/></programlisting>
+        </sect2>
+    </sect1>
     <sect1 role="taskdef" xml:id="CoverageMergerTask">
         <title>CoverageMergerTask</title>
         <para>The CoverageMergerTask merges code coverage information from external sources with an

--- a/test/classes/phing/tasks/ext/AutoloaderTaskTest.php
+++ b/test/classes/phing/tasks/ext/AutoloaderTaskTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+require_once 'phing/BuildFileTest.php';
+
+/**
+ * @author Max Romanovsky <max.romanovsky@gmail.com>
+ * @package phing.tasks.ext
+ */
+class AutoloaderTaskTest extends BuildFileTest {
+
+    public function setUp() {
+        $this->configureProject(PHING_TEST_BASE . "/etc/tasks/ext/autoloader/autoloader.xml");
+    }
+
+    public function testDefault() {
+        $this->expectBuildException("testDefault", sprintf('Provided autoloader file "%s" is not a readable file', AutoloaderTask::DEFAULT_AUTOLOAD_PATH));
+    }
+
+    public function testExisting() {
+        $this->expectLog("testExisting", 'Loading autoloader from autoload.php');
+        $this->assertTrue(class_exists('Phing_Autoload_Stub', false));
+    }
+}

--- a/test/etc/tasks/ext/autoloader/autoload.php
+++ b/test/etc/tasks/ext/autoloader/autoload.php
@@ -1,0 +1,4 @@
+<?php
+
+class Phing_Autoload_Stub {
+}

--- a/test/etc/tasks/ext/autoloader/autoloader.xml
+++ b/test/etc/tasks/ext/autoloader/autoloader.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<project name="Autoloader Test" default="build">
+    <target name="testDefault">
+        <autoloader />
+    </target>
+
+    <target name="testExisting">
+        <autoloader autoloaderpath="autoload.php"/>
+    </target>
+
+    <target name="build" depends="testDefault,testExisting"/>
+</project>


### PR DESCRIPTION
Added new Autoloader task to simplify autoload bootstrapping without execution php code in phing build file. Could be useful if build tools (e.g. phpunit or phploc) are used as Composer dependencies.
