### PR TITLE
Add composer support to PHP Documentor 2 task

### DIFF
--- a/classes/phing/tasks/ext/phpdoc/PhpDocumentor2Wrapper.php
+++ b/classes/phing/tasks/ext/phpdoc/PhpDocumentor2Wrapper.php
@@ -138,16 +138,23 @@ class PhpDocumentor2Wrapper
      */
     private function initializePhpDocumentor()
     {
-        $phpDocumentorPath = $this->findPhpDocumentorPath();
+        if (class_exists('Composer\\Autoload\\ClassLoader', false)) {
+            if (!class_exists('phpDocumentor\\Bootstrap')) {
+                throw new BuildException('You need to install PhpDocumentor 2 or add your include path to your composer installation.');
+            }
+            $phpDocumentorPath = '';
+        } else {
+            $phpDocumentorPath = $this->findPhpDocumentorPath();
 
-        if (empty($phpDocumentorPath)) {
-            throw new BuildException("Please make sure PhpDocumentor 2 is installed and on the include_path.");
+            if (empty($phpDocumentorPath)) {
+                throw new BuildException("Please make sure PhpDocumentor 2 is installed and on the include_path.");
+            }
+            
+            set_include_path($phpDocumentorPath . PATH_SEPARATOR . get_include_path());
+            
+            require_once $phpDocumentorPath . '/phpDocumentor/Bootstrap.php';        
         }
         
-        set_include_path($phpDocumentorPath . PATH_SEPARATOR . get_include_path());
-        
-        require_once $phpDocumentorPath . '/phpDocumentor/Bootstrap.php';
-            
         $this->app = \phpDocumentor\Bootstrap::createInstance()->initialize();
         
         $this->phpDocumentorPath = $phpDocumentorPath;


### PR DESCRIPTION
If PHP Documentor is installed via Composer then phing is not able to use it.
