### PR TITLE
Fix phpcpd support composer and pear

### DIFF
--- a/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
+++ b/classes/phing/tasks/ext/phpcpd/PHPCPDTask.php
@@ -194,10 +194,7 @@ class PHPCPDTask extends Task
      */
     public function main()
     {
-        if (class_exists('Composer\\Autoloader\\ClassLoader', false)) {
-            if (!class_exists('\\SebastianBergmann\\PHPCPD\\Detector\\Detector')) {
-                throw new BuildException('You need to install PHPCPD or add your include path to your composer installation.');
-            }
+        if (class_exists('Composer\\Autoload\\ClassLoader', false) && class_exists('\\SebastianBergmann\\PHPCPD\\Detector\\Strategy\\DefaultStrategy')) {
             $oldVersion = false;
         } elseif ($handler = @fopen('SebastianBergmann/PHPCPD/autoload.php', 'r', true)) {
             fclose($handler);


### PR DESCRIPTION
This should support PHPCPD installed through Composer and PEAR.
It supports both 2.0.0 and 1.4.3 when installed through PEAR.

Similar PRs #276, #257 and #253 didn't have BC with PEAR, this PR should though.
