### PR TITLE
Restore gitattributes ident / Fix not being able to switch branches right after clone

### DIFF
--- a/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
+++ b/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * $Id: 3890a82101b1b4bbafbb70e70e24258d3251bacb $
+ * $Id$
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -26,7 +26,7 @@ require_once 'phing/system/io/PhingFile.php';
  *
  * @package phing.tasks.ext.phpmd
  * @author  Benjamin Schultz <bschultz@proqrent.de>
- * @version $Id: 3890a82101b1b4bbafbb70e70e24258d3251bacb $
+ * @version $Id$
  * @since   2.4.1
  */
 class PHPMDFormatterElement

--- a/classes/phing/tasks/ext/phpmd/PHPMDTask.php
+++ b/classes/phing/tasks/ext/phpmd/PHPMDTask.php
@@ -1,6 +1,6 @@
 <?php
 /**
- *  $Id: e326bdbc8232087866d06746e509e5f6811c990a $
+ *  $Id$
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -28,7 +28,7 @@ require_once 'phing/tasks/ext/phpmd/PHPMDFormatterElement.php';
  *
  * @package phing.tasks.ext.phpmd
  * @author  Benjamin Schultz <bschultz@proqrent.de>
- * @version $Id: e326bdbc8232087866d06746e509e5f6811c990a $
+ * @version $Id$
  * @since   2.4.1
  */
 class PHPMDTask extends Task


### PR DESCRIPTION
This PR should fix the issue of not being able to switch branch right after cloning on a git client honoring gitattributes. This especially causes problems in combination with composer, see e.g. https://travis-ci.org/phpbb/phpbb/jobs/25485478#L448 (I am going to fix composer too).

```
$ git clone https://github.com/phingofficial/phing.git
Cloning into 'phing'...
remote: Reusing existing pack: 31562, done.
remote: Counting objects: 334, done.
remote: Compressing objects: 100% (290/290), done.
remote: Total 31896 (delta 218), reused 66 (delta 26)
Receiving objects: 100% (31896/31896), 28.11 MiB | 1.50 MiB/s, done.
Resolving deltas: 100% (20693/20693), done.
Checking connectivity... done.

$ cd phing/

$ git checkout phpunit-4.0-fix
error: Your local changes to the following files would be overwritten by checkout:
    classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
    classes/phing/tasks/ext/phpmd/PHPMDTask.php
Please, commit your changes or stash them before you can switch branches.
Aborting
```

```
$ git diff
diff --git a/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php b/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
index b39c123..0c02580 100644
--- a/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
+++ b/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * $Id: 3890a82101b1b4bbafbb70e70e24258d3251bacb $
+ * $Id$
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -26,7 +26,7 @@ require_once 'phing/system/io/PhingFile.php';
  *
  * @package phing.tasks.ext.phpmd
  * @author  Benjamin Schultz <bschultz@proqrent.de>
- * @version $Id: 3890a82101b1b4bbafbb70e70e24258d3251bacb $
+ * @version $Id$
  * @since   2.4.1
  */
 class PHPMDFormatterElement
diff --git a/classes/phing/tasks/ext/phpmd/PHPMDTask.php b/classes/phing/tasks/ext/phpmd/PHPMDTask.php
index c374208..e77c4a6 100644
--- a/classes/phing/tasks/ext/phpmd/PHPMDTask.php
+++ b/classes/phing/tasks/ext/phpmd/PHPMDTask.php
@@ -1,6 +1,6 @@
 <?php
 /**
- *  $Id: e326bdbc8232087866d06746e509e5f6811c990a $
+ *  $Id$
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -28,7 +28,7 @@ require_once 'phing/tasks/ext/phpmd/PHPMDFormatterElement.php';
  *
  * @package phing.tasks.ext.phpmd
  * @author  Benjamin Schultz <bschultz@proqrent.de>
- * @version $Id: e326bdbc8232087866d06746e509e5f6811c990a $
+ * @version $Id$
  * @since   2.4.1
  */
 class PHPMDTask extends Task
```

Regression from 5458862fd5afbc6d2e06ef68faf392c81ffa22c4 and e5dda050afd2d38491913c5b5e50bab7cb9f525f. No idea how these were generated, possibly by a git client not supporting gitattributes. Not sure why these commits were merged.
