### PR TITLE
Quickfix on DbDeployTask for final update change log table

### DIFF
--- a/classes/phing/tasks/ext/dbdeploy/DbDeployTask.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbDeployTask.php
@@ -269,6 +269,8 @@ class DbDeployTask extends Task
 	                         AND delta_set = \'' . $this->deltaSet . '\';' . "\n";
                 } else {
                     $sql .= substr($contents, 0, $split);
+                    // Ensuring there's a newline after the final -- //
+                    $sql .= PHP_EOL;
                     $sql .= 'UPDATE ' . DbDeployTask::$TABLE_NAME . '
 	                         SET complete_dt = ' . $this->dbmsSyntax->generateTimestamp() . '
 	                         WHERE change_number = ' . $fileChangeNumber . '


### PR DESCRIPTION
This is a quickfix on DbDeployTask where in rare cases, there's not a newline at the end of last delta.

This creates a statement like the following example:

```
-- //UPDATE changelog
```

So the last deltaset prevents the query to update changelog table to finalise the process.
