### PR TITLE
#1108 fix for pdosqlexec doesn't throw exception

### DIFF
--- a/classes/phing/tasks/ext/pdo/DummyPDOQuerySplitter.php
+++ b/classes/phing/tasks/ext/pdo/DummyPDOQuerySplitter.php
@@ -57,6 +57,16 @@ class DummyPDOQuerySplitter extends PDOQuerySplitter
             }
 
             $sql .= " " . $line . "\n";
+            
+            /**
+             * fix issue with PDO and wrong formated multistatements
+             * @issue 1108
+             */
+            if (StringHelper::endsWith($delimiter, $line))
+            {
+                break;
+            }
+            
         }
 
         return $sql;


### PR DESCRIPTION
Fix for pdosqlexec doesn't throw exception for the non-first SQL instruction.

http://www.phing.info/trac/ticket/1108

When pdosqlexec task process a dbdeploy file and we have a wrong SQL instruction but not the first instruction, PDO doesn't throw exception as explained in this bug ​https://bugs.php.net/bug.php?id=61613

To skip this bug, we can split the SQL file for a instruction for each delimiter.

Adding this control in DummyPDOQuerySplitter it works like a charm, the MySQL errors are showed.
