### PR TITLE
Bugfix: Phing exits silently, no error message when using JsMinTask and ...

### DIFF
--- a/classes/phing/tasks/ext/jsmin/JsMinTask.php
+++ b/classes/phing/tasks/ext/jsmin/JsMinTask.php
@@ -116,7 +116,7 @@ class JsMinTask extends Task
     public function main()
     {
         // if composer autoloader is not yet loaded, load it here
-        @include_one 'vendor/autoload.php';
+        @include_once 'vendor/autoload.php';
         if (!class_exists('\\JShrink\\Minifier')) {
             throw new BuildException(
                 'JsMinTask depends on JShrink being installed and on include_path.',


### PR DESCRIPTION
...no composer installed

Honestly, I think that the use of '@' should be dropped, but in any case I'm pretty sure the intention here was to use include_once and not require_once, which just exits silently here and does not throw the wanted exception.
