### PR TITLE
Remove S3 PEAR dependency

### DIFF
--- a/classes/phing/tasks/ext/Service/Amazon.php
+++ b/classes/phing/tasks/ext/Service/Amazon.php
@@ -47,6 +47,10 @@ abstract class Service_Amazon extends Task
      */
     protected $_options = array();
 
+    /**
+     * @param string $var
+     * @param mixed $val
+     */
     public function __set($var, $val)
     {
         $this->_options[$var] = $val;
@@ -77,11 +81,21 @@ abstract class Service_Amazon extends Task
         return $this->_options[$var];
     }
 
+    /**
+     * @param string $var
+     *
+     * @return bool
+     */
     public function __isset($var)
     {
         return array_key_exists($var, $this->_options);
     }
 
+    /**
+     * @param string $key
+     *
+     * @throws BuildException if $key is a empty string
+     */
     public function setKey($key)
     {
         if (empty($key) || !is_string($key)) {
@@ -91,6 +105,11 @@ abstract class Service_Amazon extends Task
         $this->key = $key;
     }
 
+    /**
+     * @return string
+     *
+     * @throws BuildException if key is not set
+     */
     public function getKey()
     {
         if (!($key = $this->key)) {
@@ -100,6 +119,11 @@ abstract class Service_Amazon extends Task
         return $key;
     }
 
+    /**
+     * @param string $secret
+     *
+     * @throws BuildException if $secret is a empty string
+     */
     public function setSecret($secret)
     {
         if (empty($secret) || !is_string($secret)) {
@@ -109,6 +133,11 @@ abstract class Service_Amazon extends Task
         $this->secret = $secret;
     }
 
+    /**
+     * @return string
+     *
+     * @throws BuildException if secret is not set
+     */
     public function getSecret()
     {
         if (!($secret = $this->secret)) {

--- a/classes/phing/tasks/ext/Service/Amazon/S3.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3.php
@@ -49,7 +49,6 @@ abstract class Service_Amazon_S3 extends Service_Amazon
     /**
      * We only instantiate the client once per task call
      *
-     * @access public
      * @return Services_Amazon_S3
      */
     public function getClient()
@@ -67,6 +66,11 @@ abstract class Service_Amazon_S3 extends Service_Amazon
         return $this->_client;
     }
 
+    /**
+     * @param string $bucket
+     *
+     * @throws BuildException if $bucket is a empty string
+     */
     public function setBucket($bucket)
     {
         if (empty($bucket) || !is_string($bucket)) {
@@ -76,6 +80,11 @@ abstract class Service_Amazon_S3 extends Service_Amazon
         $this->bucket = (string) $bucket;
     }
 
+    /**
+     * @return string
+     *
+     * @throws BuildException if bucket is not set
+     */
     public function getBucket()
     {
         if (!($bucket = $this->bucket)) {
@@ -88,8 +97,8 @@ abstract class Service_Amazon_S3 extends Service_Amazon
     /**
      * Returns an instance of Services_Amazon_S3_Resource_Object
      *
-     * @access public
-     * @param  mixed                              $object
+     * @param  mixed $object
+     *
      * @return Services_Amazon_S3_Resource_Object
      */
     public function getObjectInstance($object)
@@ -100,8 +109,8 @@ abstract class Service_Amazon_S3 extends Service_Amazon
     /**
      * Check if the object already exists in the current bucket
      *
-     * @access public
      * @param  mixed $object
+     *
      * @return bool
      */
     public function isObjectAvailable($object)
@@ -113,6 +122,7 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      * Returns an instance of Services_Amazon_S3_Resource_Bucket
      *
      * @access public
+     *
      * @return \Aws\S3\S3Client
      */
     public function getBucketInstance()
@@ -124,35 +134,12 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      * Check if the current bucket is available
      *
      * @access public
+     *
      * @return bool
      */
     public function isBucketAvailable()
     {
         return $this->getBucketInstance()->doesBucketExist($this->getBucket());
-    }
-
-    /**
-     * Get the contents of an object (by it's name)
-     *
-     * @access public
-     * @param  string $object
-     * @return mixed
-     */
-    public function getObjectContents($object)
-    {
-        if (!$this->isBucketAvailable($this->getBucket())) {
-            throw new BuildException('Bucket doesn\'t exist or wrong permissions');
-        }
-
-        $bucket = $this->getClient()->getBucket($this->getBucket());
-        if (!$this->isObjectAvailable($object)) {
-            throw new BuildException('Object not available: ' . $object);
-        }
-
-        $object = $this->getObjectInstance($object);
-        $object->load();
-
-        return $object->data;
     }
 
     /**

--- a/classes/phing/tasks/ext/Service/Amazon/S3.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3.php
@@ -163,9 +163,8 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      */
     public function createBucket()
     {
-        $bucket = $this->getBucketInstance();
-        $bucket->name = $this->getBucket();
-        $bucket->save();
+        $client = $this->getBucketInstance();
+        $client->createBucket(array('Bucket' => $this->getBucket()));
 
         return $this->isBucketAvailable();
     }

--- a/classes/phing/tasks/ext/Service/Amazon/S3.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3.php
@@ -54,10 +54,14 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      */
     public function getClient()
     {
-        require_once "Services/Amazon/S3.php";
 
         if ($this->_client === null) {
-            $this->_client = Services_Amazon_S3::getAccount($this->getKey(), $this->getSecret());
+            $s3Client = Aws\S3\S3Client::factory(array(
+                'key'    => $this->getKey(),
+                'secret' => $this->getSecret(),
+            ));
+
+            $this->_client = $s3Client;
         }
 
         return $this->_client;
@@ -109,11 +113,11 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      * Returns an instance of Services_Amazon_S3_Resource_Bucket
      *
      * @access public
-     * @return Services_Amazon_S3_Resource_Bucket
+     * @return \Aws\S3\S3Client
      */
     public function getBucketInstance()
     {
-        return $this->getClient()->getBucket($this->getBucket());
+        return $this->getClient();
     }
 
     /**
@@ -124,7 +128,7 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      */
     public function isBucketAvailable()
     {
-        return (bool) $this->getBucketInstance($this->getBucket())->load();
+        return $this->getBucketInstance()->doesBucketExist($this->getBucket());
     }
 
     /**

--- a/classes/phing/tasks/ext/Service/Amazon/S3.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3.php
@@ -103,7 +103,7 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      */
     public function getObjectInstance($object)
     {
-        return $this->getBucketInstance()->getObject($object);
+        return $this->getClientInstance()->getObject($object);
     }
 
     /**
@@ -125,7 +125,7 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      *
      * @return \Aws\S3\S3Client
      */
-    public function getBucketInstance()
+    public function getClientInstance()
     {
         return $this->getClient();
     }
@@ -139,7 +139,7 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      */
     public function isBucketAvailable()
     {
-        return $this->getBucketInstance()->doesBucketExist($this->getBucket());
+        return $this->getClientInstance()->doesBucketExist($this->getBucket());
     }
 
     /**
@@ -150,7 +150,7 @@ abstract class Service_Amazon_S3 extends Service_Amazon
      */
     public function createBucket()
     {
-        $client = $this->getBucketInstance();
+        $client = $this->getClientInstance();
         $client->createBucket(array('Bucket' => $this->getBucket()));
 
         return $this->isBucketAvailable();

--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3GetTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3GetTask.php
@@ -103,6 +103,11 @@ class S3GetTask extends Service_Amazon_S3
             $target = rtrim($target, '/') . '/' . $this->getObject();
         }
 
-        file_put_contents($target, $this->getObjectContents($this->getObject()));
+        $client = $this->getBucketInstance();
+        $client->getObject(array(
+            'Bucket' => $this->getBucket(),
+            'Key'    => $this->getObject(),
+            'SaveAs' => $target
+        ));
     }
 }

--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3GetTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3GetTask.php
@@ -103,7 +103,7 @@ class S3GetTask extends Service_Amazon_S3
             $target = rtrim($target, '/') . '/' . $this->getObject();
         }
 
-        $client = $this->getBucketInstance();
+        $client = $this->getClientInstance();
         $client->getObject(array(
             'Bucket' => $this->getBucket(),
             'Key'    => $this->getObject(),

--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -138,6 +138,11 @@ class S3PutTask extends Service_Amazon_S3
      */
     protected $_fileNameOnly = false;
 
+    /**
+     * @param $source
+     *
+     * @throws BuildException if $source is not readable
+     */
     public function setSource($source)
     {
         if (!is_readable($source)) {
@@ -147,6 +152,11 @@ class S3PutTask extends Service_Amazon_S3
         $this->_source = $source;
     }
 
+    /**
+     * @return string path to file
+     *
+     * @throws BuildException if source is null
+     */
     public function getSource()
     {
         if ($this->_content !== null) {
@@ -163,6 +173,11 @@ class S3PutTask extends Service_Amazon_S3
         return $this->_source;
     }
 
+    /**
+     * @param string $content
+     *
+     * @throws BuildException if $content is a empty string
+     */
     public function setContent($content)
     {
         if (empty($content) || !is_string($content)) {
@@ -172,6 +187,11 @@ class S3PutTask extends Service_Amazon_S3
         $this->_content = $content;
     }
 
+    /**
+     * @return string
+     *
+     * @throws BuildException if content is null
+     */
     public function getContent()
     {
         if ($this->_content === null) {
@@ -181,6 +201,11 @@ class S3PutTask extends Service_Amazon_S3
         return $this->_content;
     }
 
+    /**
+     * @param $object
+     *
+     * @throws BuildException
+     */
     public function setObject($object)
     {
         if (empty($object) || !is_string($object)) {
@@ -190,6 +215,11 @@ class S3PutTask extends Service_Amazon_S3
         $this->_object = $object;
     }
 
+    /**
+     * @return object
+     *
+     * @throws BuildException if the object is not set
+     */
     public function getObject()
     {
         if ($this->_object === null) {
@@ -199,25 +229,39 @@ class S3PutTask extends Service_Amazon_S3
         return $this->_object;
     }
 
+    /**
+     * @param $permission
+     *
+     * @throws BuildException if $permission is not a valid ACL rule
+     */
     public function setAcl($permission)
     {
-        $valid_acl = array('private', 'public-read', 'public-read-write', 'authenticated-read');
-        if (empty($permission) || !is_string($permission) || !in_array($permission, $valid_acl)) {
-            throw new BuildException('Object must be one of the following values: ' . implode('|', $valid_acl));
+        $validAcl = array('private', 'public-read', 'public-read-write', 'authenticated-read');
+        if (empty($permission) || !is_string($permission) || !in_array($permission, $validAcl)) {
+            throw new BuildException('Object must be one of the following values: ' . implode('|', $validAcl));
         }
         $this->_acl = $permission;
     }
 
+    /**
+     * @return string
+     */
     public function getAcl()
     {
         return $this->_acl;
     }
 
+    /**
+     * @param string $contentType
+     */
     public function setContentType($contentType)
     {
         $this->_contentType = $contentType;
     }
 
+    /**
+     * @return string
+     */
     public function getContentType()
     {
         if ($this->_contentType === 'auto') {
@@ -232,11 +276,17 @@ class S3PutTask extends Service_Amazon_S3
         }
     }
 
+    /**
+     * @param bool $createBuckets
+     */
     public function setCreateBuckets($createBuckets)
     {
         $this->_createBuckets = (bool) $createBuckets;
     }
 
+    /**
+     * @return bool
+     */
     public function getCreateBuckets()
     {
         return (bool) $this->_createBuckets;
@@ -276,8 +326,7 @@ class S3PutTask extends Service_Amazon_S3
     /**
      * Return if content is gzipped.
      *
-     * @return booleand
-     *                  Indicate if content is gzipped.
+     * @return booleand Indicate if content is gzipped.
      */
     public function getGzip()
     {
@@ -287,8 +336,7 @@ class S3PutTask extends Service_Amazon_S3
     /**
      * Generate HTTPHEader array sent to S3.
      *
-     * @return array
-     *               HttpHeader to set in S3 Object.
+     * @return array HttpHeader to set in S3 Object.
      */
     protected function getHttpHeaders()
     {
@@ -303,6 +351,9 @@ class S3PutTask extends Service_Amazon_S3
         return $headers;
     }
 
+    /**
+     * @param bool $fileNameOnly
+     */
     public function setFileNameOnly($fileNameOnly)
     {
         $this->_fileNameOnly = (bool) $fileNameOnly;
@@ -311,7 +362,6 @@ class S3PutTask extends Service_Amazon_S3
     /**
      * creator for _filesets
      *
-     * @access public
      * @return FileSet
      */
     public function createFileset()
@@ -324,7 +374,6 @@ class S3PutTask extends Service_Amazon_S3
     /**
      * getter for _filesets
      *
-     * @access public
      * @return array
      */
     public function getFilesets()
@@ -339,7 +388,10 @@ class S3PutTask extends Service_Amazon_S3
      * otherwise, we read from _source
      *
      * @access public
+     *
      * @return string
+     *
+     * @throws BuildException if the given source is not a file
      */
     public function getObjectData()
     {
@@ -355,8 +407,8 @@ class S3PutTask extends Service_Amazon_S3
     /**
      * Store the object on S3
      *
-     * @access public
-     * @return void
+     * @throws BuildException if the given bucket can not be created
+     * @throws BuildException if the given bucket not exists and "create bucket" is not enabled
      */
     public function execute()
     {
@@ -400,19 +452,23 @@ class S3PutTask extends Service_Amazon_S3
                 }
             }
 
-            return true;
+            return;
         }
 
         $this->saveObject($this->getObject(), $this->getSource());
     }
 
-    protected function saveObject($object, $data)
+    /**
+     * @param string $key
+     * @param string $sourceFile
+     */
+    protected function saveObject($key, $sourceFile)
     {
         $client = $this->getBucketInstance();
-        $result = $client->putObject(array(
+        $client->putObject(array(
             'Bucket'     => $this->getBucket(),
-            'Key'        => $object,
-            'SourceFile' => $data
+            'Key'        => $key,
+            'SourceFile' => $sourceFile
         ));
     }
 }

--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -464,7 +464,7 @@ class S3PutTask extends Service_Amazon_S3
      */
     protected function saveObject($key, $sourceFile)
     {
-        $client = $this->getBucketInstance();
+        $client = $this->getClientInstance();
         $client->putObject(array(
             'Bucket'     => $this->getBucket(),
             'Key'        => $key,

--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -149,6 +149,13 @@ class S3PutTask extends Service_Amazon_S3
 
     public function getSource()
     {
+        if ($this->_content !== null) {
+            $tempFile = tempnam('/tmp', 's3_put_');
+
+            file_put_contents($tempFile, $this->_content);
+            $this->_source = $tempFile;
+        }
+
         if ($this->_source === null) {
             throw new BuildException('Source is not set');
         }

--- a/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
+++ b/classes/phing/tasks/ext/Service/Amazon/S3/S3PutTask.php
@@ -336,21 +336,13 @@ class S3PutTask extends Service_Amazon_S3
      */
     public function getObjectData()
     {
-        return $this->getSource();
+        $source = $this->getSource();
 
-        try {
-            $content = $this->getContent();
-        } catch (BuildException $e) {
-            $source = $this->getSource();
-
-            if (!is_file($source)) {
-                throw new BuildException('Currently only files can be used as source');
-            }
-
-            $content = file_get_contents($source);
+        if (!is_file($source)) {
+            throw new BuildException('Currently only files can be used as source');
         }
 
-        return $content;
+        return $source;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
 	"pear-pear.php.net/XML_Serializer": "0.20.x",
 	"squizlabs/php_codesniffer": "1.5.x",
 	"lastcraft/simpletest": "@dev",
-	"ext-pdo_sqlite": "*"
+	"ext-pdo_sqlite": "*",
+        "aws/aws-sdk-php": "2.6.*@dev"
     },
     "autoload": {
         "classmap": ["classes/phing/"]


### PR DESCRIPTION
In order to use the phing.phar without any dependencies to PEAR, I have refactored the `S3PutTask` and `S3GetTask`. Both tasks use the [AWS SDK](https://github.com/aws/aws-sdk-php) to put and get files from S3.  
