### PR TITLE
Alias master branch as 2.9.x for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,11 @@
     "config": {
         "bin-dir": "bin"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.9.x-dev"
+        }
+    },
     "suggest": {
         "phpdocumentor/phpdocumentor": "Documentation Generator for PHP",
         "sebastian/phpcpd": "Copy/Paste Detector (CPD) for PHP code",


### PR DESCRIPTION
The `master` branch is currently only available by requiring `dev-master` in a downstream composer.json file. This is not recommended because:
- It creates a hard dependency on your branch naming strategy
- It is too loose, and may expose end-users to unexpected major version upgrades
- It can cause dependency resolution conflicts if other packages impose a numeric version constraint on phing/phing

By adding the branch alias, users can either require `"phing/phing": "2.9.*@dev"` directly, or can set an overall `minimum-stability` flag in their composer.json to accept the dev version of the package. Anyone already using `dev-master` can continue to do so.

Note that you would then need to update the branch-alias once master becomes the development branch for eg 3.0.x etc.
