### PR TITLE
Adds ImportMultiTask.

### DIFF
--- a/docs/docbook5/en/source/appendixes/coretasks.xml
+++ b/docs/docbook5/en/source/appendixes/coretasks.xml
@@ -1903,6 +1903,15 @@
             <title>Examples</title>
             <programlisting language="xml">&lt;import file="path/to/build.xml"/>
 &lt;import file="path/to/build.xml" optional="true"/></programlisting>
+            <para>Additionally, <literal>ImportTask</literal> supports Filesets, i.e. you can easily
+                include/exclude one or more files. For more information, see <xref
+                    xlink:href="#app.coretypes"/>.</para>
+            <programlisting language="xml">&lt;import" >
+  &lt;fileset dir=".">
+    &lt;include name="path/to/build.xml" />
+  &lt;/fileset>
+  &lt;filelist dir="." files="path/to/build.xml"/>
+&lt;/import></programlisting>
         </sect2>
     </sect1>
     <sect1 role="taskdef" xml:id="IncludePathTask">

--- a/test/classes/phing/tasks/ImportTaskTest.php
+++ b/test/classes/phing/tasks/ImportTaskTest.php
@@ -60,6 +60,14 @@ class ImportTaskTest extends BuildFileTest
         $this->assertInLogs("This is " . $f1->getAbsolutePath() . " imported2 target.");
     }
 
+    public function testImportedMultiTarget()
+    {
+        $this->configureProject(PHING_TEST_BASE . "/etc/tasks/importing-multi.xml");
+
+        $this->assertInLogs("parsing buildfile imported-multi-1.xml");
+        $this->assertInLogs("parsing buildfile imported-multi-2.xml");
+    }
+
     public function testCascadeTarget()
     {
         $f1 = new PhingFile(PHING_TEST_BASE . "/etc/tasks/imports/imported.xml");

--- a/test/etc/tasks/importing-multi.xml
+++ b/test/etc/tasks/importing-multi.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<project name="importing-multi" default="">
+
+    <import optional="true">
+        <fileset dir="imports">
+            <patternset>
+                <include name="**/imported-multi-*.xml"/>
+            </patternset>
+        </fileset>
+    </import>
+
+</project>

--- a/test/etc/tasks/imports/imported-multi-1.xml
+++ b/test/etc/tasks/imports/imported-multi-1.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<project name="imported-multi-1" default="">
+
+    <target name="main">
+        <echo>This is import task 1 main target.</echo>
+    </target>
+
+</project>

--- a/test/etc/tasks/imports/imported-multi-2.xml
+++ b/test/etc/tasks/imports/imported-multi-2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<project name="imported-multi-2" default="">
+
+    <target name="main">
+        <echo>This is import task 2 main target.</echo>
+    </target>
+
+</project>


### PR DESCRIPTION
**Use case**

I pull down alot of different build.xml files with composer. I don't want to have to add multiple import references, especially if I am adding a new library.

Giving Phing and almost "autoload" kind of functionality.

**Solution**

Create a ImportMultiTask object for this case.

```
<import-multi files="vendor/previousnext/*/build*.xml" optional="true" />
```

**Help**

Can I please get some guidance on:

* If this could be committed to Phing.
* How I can get it over the line so I can be committed.