### PR TITLE
Automatically escape delimiter and add unit tests for PregEngine.

### DIFF
--- a/classes/phing/util/regexp/PregEngine.php
+++ b/classes/phing/util/regexp/PregEngine.php
@@ -30,7 +30,6 @@ require_once 'phing/util/regexp/RegexpEngine.php';
  */
 class PregEngine implements RegexpEngine
 {
-
     /**
      * Set to null by default to distinguish between false and not set
      * @var boolean
@@ -49,6 +48,11 @@ class PregEngine implements RegexpEngine
      * @var string
      */
     private $modifiers = null;
+
+    /**
+     * Pattern delimiter.
+     */
+    const DELIMITER = '`';
 
     /**
      * Sets pattern modifiers for regex engine
@@ -129,8 +133,7 @@ class PregEngine implements RegexpEngine
      */
     private function preparePattern($pattern)
     {
-        $delimiter = '`'; // Use an uncommon delimiter so the following block is avoided more often.
-        $delimiterPattern = '/\\\\*`/';
+        $delimiterPattern = '/\\\\*' . self::DELIMITER . '/';
 
         // The following block escapes usages of the delimiter in the pattern if it's not already escaped.
         if (preg_match_all($delimiterPattern, $pattern, $matches, PREG_OFFSET_CAPTURE)) {
@@ -148,7 +151,7 @@ class PregEngine implements RegexpEngine
             }
         }
 
-        return $delimiter . $pattern . $delimiter . $this->getModifiers();
+        return self::DELIMITER . $pattern . self::DELIMITER . $this->getModifiers();
     }
 
     /**

--- a/test/classes/phing/util/regexp/PregEngineTest.php
+++ b/test/classes/phing/util/regexp/PregEngineTest.php
@@ -22,24 +22,42 @@
  * @package phing.util
  */
 
+require_once 'phing/util/regexp/PregEngine.php';
+
 /**
  * Class PregEngineTest
  *
  * Test cases for phing/util/regexp/PregEngine
  */
-class PregEngineTest extends PHPUnit_Framework_TestCase {
-
+class PregEngineTest extends PHPUnit_Framework_TestCase
+{
     /**
-     * Test setting of the ignore-case flag.
+     * Test the default ignore-case value.
      */
-    public function testSetIgnoreCase()
+    public function testIgnoreCaseDefaultValue()
     {
         $pregEngine = new PregEngine();
         $this->assertNull($pregEngine->getIgnoreCase());
+    }
+
+    /**
+     * Test setting the ignore-case flag to true.
+     */
+    public function testIgnoreCaseSetTrue()
+    {
+        $pregEngine = new PregEngine();
 
         $pregEngine->setIgnoreCase(true);
         $this->assertTrue($pregEngine->getIgnoreCase());
         $this->assertEquals('i', $pregEngine->getModifiers());
+    }
+
+    /**
+     * Test setting the ignore-case flag to false.
+     */
+    public function testIgnoreCaseSetFalse()
+    {
+        $pregEngine = new PregEngine();
 
         $pregEngine->setIgnoreCase(false);
         $this->assertFalse($pregEngine->getIgnoreCase());
@@ -47,12 +65,20 @@ class PregEngineTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Test setting of the multiline flag.
+     * Test the default multi-line value.
      */
-    public function testSetMultiline()
+    public function testMultiLineDefaultValue()
     {
         $pregEngine = new PregEngine();
         $this->assertNull($pregEngine->getMultiline());
+    }
+
+    /**
+     * Test setting the multi-line flag to true.
+     */
+    public function testMultilineSetTrue()
+    {
+        $pregEngine = new PregEngine();
 
         $pregEngine->setMultiline(true);
         $this->assertTrue($pregEngine->getMultiline());
@@ -64,27 +90,105 @@ class PregEngineTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Test setting of modifiers
+     * Test setting the multi-line flag to true.
      */
-    public function testSetModifiers()
+    public function testSMultilineSetFalse()
     {
         $pregEngine = new PregEngine();
+
+        $pregEngine->setMultiline(true);
+        $this->assertTrue($pregEngine->getMultiline());
+        $this->assertEquals('s', $pregEngine->getModifiers());
+
+        $pregEngine->setMultiline(false);
+        $this->assertFalse($pregEngine->getMultiline());
         $this->assertSame('', $pregEngine->getModifiers());
-
-        $pregEngine->setModifiers('guug');
-        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'u'), 'Duplicate modifier characters should be reduced to one.');
-        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'g'), 'Duplicate modifier characters should be reduced to one.');
-
-        $pregEngine = new PregEngine();
-        $pregEngine->setModifiers('iii');
-        $pregEngine->setIgnoreCase(false);
-        $this->assertEquals(0, substr_count($pregEngine->getModifiers() , 'i'), 'Modifier character for ignoring case should be removed when setting ignoreCase to FALSE.');
     }
 
     /**
-     * Test regular expressions match functionality
+     * Test the default modifiers value.
      */
-    public function testMatch()
+    public function testModifiersDefaultValue()
+    {
+        $pregEngine = new PregEngine();
+        $this->assertSame('', $pregEngine->getModifiers());
+    }
+
+    /**
+     * Test setting of the modifiers.
+     */
+    public function testModifiersSet()
+    {
+        $pregEngine = new PregEngine();
+        $pregEngine->setModifiers('gu');
+        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'u'));
+        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'g'));
+    }
+
+    /**
+     * Test setting ignore-case through the modifier.
+     * @todo This is a new test that fails due to a pre-existing condition.
+     */
+//    public function testModifiersSetIgnoreCase()
+//    {
+//        $pregEngine = new PregEngine();
+//        $pregEngine->setModifiers('i');
+//        $this->assertTrue($pregEngine->getIgnoreCase());
+//        $this->assertEquals('i', $pregEngine->getModifiers());
+//    }
+
+    /**
+     * Test setting multi-line through the modifier.
+     * @todo This is a new test that fails due to a pre-existing conditions.
+     */
+//    public function testModifiersSetMultiline()
+//    {
+//        $pregEngine = new PregEngine();
+//        $pregEngine->setModifiers('s');
+//        $this->assertTrue($pregEngine->getMultiline());
+//        $this->assertEquals('s', $pregEngine->getModifiers());
+//    }
+
+    /**
+     * Test duplicate modifier flags are removed.
+     */
+    public function testModifiersSetRemoveDuplicates()
+    {
+        $pregEngine = new PregEngine();
+
+        $pregEngine->setModifiers('guummmii');
+        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'u'));
+        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'g'));
+        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'i'));
+        $this->assertEquals(1, substr_count($pregEngine->getModifiers() , 'm'));
+    }
+
+    /**
+     * Tests setting the ignore-case flag with the modifier method, then unsetting using ignore-case method.
+     */
+    public function testModifierSetIgnoreCaseUnset()
+    {
+        $pregEngine = new PregEngine();
+        $pregEngine->setModifiers('i');
+        $pregEngine->setIgnoreCase(false);
+        $this->assertEquals('', $pregEngine->getModifiers());
+    }
+
+    /**
+     * Tests setting the ignore-case flag with the modifier method, then unsetting using ignore-case method.
+     */
+    public function testModifierSetMultilineUnset()
+    {
+        $pregEngine = new PregEngine();
+        $pregEngine->setModifiers('s');
+        $pregEngine->setMultiline(false);
+        $this->assertEquals('', $pregEngine->getModifiers());
+    }
+
+    /**
+     * Test pattern match functionality.
+     */
+    public function testPatternMatch()
     {
         $pregEngine = new PregEngine();
         $pattern = '\d{2}';
@@ -92,17 +196,27 @@ class PregEngineTest extends PHPUnit_Framework_TestCase {
         $pregEngine->match($pattern, $source, $matches);
 
         $this->assertEquals(array('12'), $matches);
+    }
 
+    /**
+     * Test match for pattern containing the PregEngine delimiter.
+     */
+    public function testPatternMatchWithPatternDelimiter()
+    {
         $pregEngine = new PregEngine();
-        $pattern = '/';
-        $source = '/';
+        $pattern = PregEngine::DELIMITER;
+        $source = PregEngine::DELIMITER;
         $pregEngine->match($pattern, $source, $matches);
+    }
 
-        $this->assertEquals(array($source), $matches);
-
+    /**
+     * Test match for pattern containing the PregEngine delimiter with irregular escaping.
+     */
+    public function testPatternMatchWithEscapedPatternDelimiter()
+    {
         $pregEngine = new PregEngine();
-        $pattern = '\\\\\\\\`abc\\\\\\`123\\\\`efg\\`456`';
-        $source = '\\\\`abc\\`123\\`efg`456`';
+        $pattern = '\\\\\\\\' . PregEngine::DELIMITER . 'abc\\\\\\' . PregEngine::DELIMITER . '123\\\\' . PregEngine::DELIMITER . 'efg\\' . PregEngine::DELIMITER . '456' . PregEngine::DELIMITER;
+        $source = '\\\\' . PregEngine::DELIMITER . 'abc\\' . PregEngine::DELIMITER . '123\\' . PregEngine::DELIMITER . 'efg' . PregEngine::DELIMITER . '456' . PregEngine::DELIMITER;
         $pregEngine->match($pattern, $source, $matches);
 
         $this->assertEquals(array($source), $matches, 'The match method did not properly escape uses of the delimiter in the regular expression.');
@@ -122,7 +236,7 @@ class PregEngineTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Test regular expression replace functionality
+     * Test pattern replace.
      */
     public function testReplace()
     {
@@ -132,7 +246,13 @@ class PregEngineTest extends PHPUnit_Framework_TestCase {
         $result = $pregEngine->replace($pattern, 'ab', $source);
 
         $this->assertEquals('abab', $result);
+    }
 
+    /**
+     * Test pattern replace using \1 back reference format (as opposed to $1).
+     */
+    public function testReplaceWithBackReference()
+    {
         $pregEngine = new PregEngine();
         $pattern = '(\d{2})(\d{2})';
         $source = '1234';


### PR DESCRIPTION
Writing a regular pattern that used a backtick would cause an error unless the user knows that backtick has been used as the preg delimiter, and knows to escape it.

This change no longer requires the user to know what the delimiter is and have to escape it themselves.

Users who have already written regular expressions that escape the backtick shouldn't be impacted by this change.  The escaping will be unnecessary, but it will still match what it previously matched.

It also introduces unit tests for the class.
