### PR TITLE
Removed irrelevant suggestions from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,18 +60,5 @@
         "branch-alias": {
             "dev-master": "2.9.x-dev"
         }
-    },
-    "suggest": {
-        "phpdocumentor/phpdocumentor": "Documentation Generator for PHP",
-        "sebastian/phpcpd": "Copy/Paste Detector (CPD) for PHP code",
-        "phpmd/phpmd": "PHP version of PMD tool",
-        "pdepend/pdepend": "PHP version of JDepend",
-        "phploc/phploc": "A tool for quickly measuring the size of a PHP project",
-        "phpunit/phpunit": "The PHP Unit Testing Framework",
-        "phpunit/php-code-coverage": "Library that provides collection, processing, and rendering functionality for PHP code coverage information",
-        "pear/versioncontrol_svn": "A simple OO-style interface for Subversion, the free/open-source version control system",
-        "pear/versioncontrol_git": "A library that provides OO interface to handle Git repository",
-        "pear/archive_tar": "Tar file management class",
-        "tedivm/jshrink": "Javascript Minifier built in PHP"
     }
 }


### PR DESCRIPTION
These suggestions are absolutely irrelevant. Imagine if Grunt or Gulp suggested to install some CSS/JS optimisers alongside with Jasmine (which is a testing tool)
