### PR TITLE
chmod doesn't throw exceptions

### DIFF
--- a/classes/phing/system/io/FileSystem.php
+++ b/classes/phing/system/io/FileSystem.php
@@ -517,12 +517,7 @@ abstract class FileSystem
             throw new IOException($msg);
         }
 
-        try {
-            $dest->setMode($src->getMode());
-        } catch (Exception $exc) {
-            // [MA] does chmod returns an error on systems that do not support it ?
-            // eat it up for now.
-        }
+        $dest->setMode($src->getMode());
     }
 
     /**


### PR DESCRIPTION
even on systems that don't support it, as windows
