### PR TITLE
Allow to use sticky option with boolean values as strings on GrowlNotifyTask

### DIFF
--- a/classes/phing/tasks/ext/GrowlNotifyTask.php
+++ b/classes/phing/tasks/ext/GrowlNotifyTask.php
@@ -145,18 +145,10 @@ class GrowlNotifyTask extends Task
      * @param bool $sticky (optional) Notification should be sticky
      *
      * @return void
-     * @throws BuildException
      */
     public function setSticky($sticky = true)
     {
-        if (!is_bool($sticky)) {
-            throw new BuildException(
-                '"sticky" attribute is invalid.' .
-                ' Expect to be a boolean, actual is ' . gettype($sticky)
-            );
-        }
-
-        $this->sticky = $sticky;
+        $this->sticky = (bool) $sticky;
     }
 
     /**

--- a/test/classes/phing/tasks/ext/GrowlNotifyTaskTest.php
+++ b/test/classes/phing/tasks/ext/GrowlNotifyTaskTest.php
@@ -131,7 +131,7 @@ class GrowlNotifyTaskTest extends BuildFileTest
     public function testSingleStickyNotification()
     {
         $this->mockTask->setMessage('Sticky message !!!');
-        $this->mockTask->setSticky(true);
+        $this->mockTask->setSticky('true');
 
         $this->executeTarget('test');
         $this->assertInLogs('Notification-Sticky: 1', Project::MSG_DEBUG);


### PR DESCRIPTION
Rather than test regression of my old proposal https://github.com/phingofficial/phing/pull/180, here is a patch for GrowlNotifyTask that will allow to use the sticky option !
