### PR TITLE
Resetting $msgOutputLevel on shutdown.

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -1636,6 +1636,7 @@ class Phing
      */
     public static function shutdown()
     {
+        self::$msgOutputLevel = Project::MSG_INFO;
         self::restoreIni();
         self::getTimer()->stop();
     }


### PR DESCRIPTION
Fixes the problem described in Ticket #1147 (http://www.phing.info/trac/ticket/1147)
