### PR TITLE
Fix archive without phar extension - #1127

### DIFF
--- a/build/phing-stub.php
+++ b/build/phing-stub.php
@@ -8,6 +8,12 @@ if (DIRECTORY_SEPARATOR != '\\' && function_exists('posix_isatty') && @posix_isa
 }
 $argc++;
 
-include 'phar://' . __FILE__ . '/bin/phing.php';
+try {
+    Phar::mapPhar('phing.phar');
+    include 'phar://phing.phar/bin/phing.php';
+} catch (PharException $e) {
+    echo $e->getMessage();
+    die('Cannot initialize Phar');
+}
 
 __HALT_COMPILER();


### PR DESCRIPTION
Fix [#1127](http://www.phing.info/trac/ticket/1127)

When using the phar archive without the phar extension, the following error occurs: 

```
PHP Warning:  include(phar:///usr/local/bin/phing/bin/phing.php): failed to open stream: phar error: invalid url or non-existent phar "phar:///usr/local/bin/phing/bin/phing.php" in /usr/local/bin/phing on line 11
```

This fixes the error by using a relative include path in the phar-stub
