### PR TITLE
Allow encoding using IonCube encoder for PHP5.5

### DIFF
--- a/classes/phing/tasks/ext/ioncube/IoncubeEncoderTask.php
+++ b/classes/phing/tasks/ext/ioncube/IoncubeEncoderTask.php
@@ -578,7 +578,7 @@ class IoncubeEncoderTask extends Task
     {
         $arguments = $this->constructArguments();
 
-        if (in_array($this->phpVersion, array(5, 53, 54))) {
+        if (in_array($this->phpVersion, array(5, 53, 54, 55))) {
             $encoderName = $this->encoderName . $this->phpVersion;
         } else {
             $encoderName = $this->encoderName;


### PR DESCRIPTION
Only added 5.5 as they do not support 5.6 (yet)
