### PR TITLE
Added PhingVersion condition / task

### DIFF
--- a/classes/phing/tasks/defaults.properties
+++ b/classes/phing/tasks/defaults.properties
@@ -28,6 +28,7 @@ mkdir=phing.tasks.system.MkdirTask
 move=phing.tasks.system.MoveTask
 phing=phing.tasks.system.PhingTask
 phingcall=phing.tasks.system.PhingCallTask
+phingversion=phing.tasks.system.condition.PhingVersion
 php=phing.tasks.system.PhpEvalTask
 property=phing.tasks.system.PropertyTask
 propertyprompt=phing.tasks.system.PropertyPromptTask

--- a/classes/phing/tasks/system/condition/ConditionBase.php
+++ b/classes/phing/tasks/system/condition/ConditionBase.php
@@ -201,6 +201,14 @@ abstract class ConditionBase extends ProjectComponent
         return $this->conditions[$num - 1];
     }
 
+    public function createPhingVersion()
+    {
+        include_once 'phing/tasks/system/condition/PhingVersion.php';
+        $num = array_push($this->conditions, new PhingVersion());
+
+        return $this->conditions[$num - 1];
+    }
+
     public function createHasFreeSpace()
     {
         include_once 'phing/tasks/system/condition/HasFreeSpaceCondition.php';

--- a/classes/phing/tasks/system/condition/PhingVersion.php
+++ b/classes/phing/tasks/system/condition/PhingVersion.php
@@ -24,7 +24,7 @@ include_once 'phing/tasks/system/condition/Condition.php';
 /**
  * An phing version condition/task.
  *
- * @author    Siad Ardroumli <siad.ardroumli@gmail.org>
+ * @author    Siad Ardroumli <siad.ardroumli@gmail.com>
  * @package   phing.tasks.system
  */
 class PhingVersion extends Task implements Condition

--- a/classes/phing/tasks/system/condition/PhingVersion.php
+++ b/classes/phing/tasks/system/condition/PhingVersion.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+include_once 'phing/BuildException.php';
+include_once 'phing/Task.php';
+include_once 'phing/tasks/system/condition/Condition.php';
+
+/**
+ * An phing version condition/task.
+ *
+ * @author    Siad Ardroumli <siad.ardroumli@gmail.org>
+ * @package   phing.tasks.system
+ */
+class PhingVersion extends Task implements Condition
+{
+    private $atLeast = null;
+    private $exactly = null;
+    private $propertyname = null;
+
+    /**
+     * Run as a task.
+     * @throws BuildException if an error occurs.
+     */
+    public function main()
+    {
+        if ($this->propertyname == null) {
+            throw new BuildException("'property' must be set.");
+        }
+        if ($this->atLeast != null || $this->exactly != null) {
+            // If condition values are set, evaluate the condition
+            if ($this->evaluate()) {
+                $this->getProject()->setNewProperty($this->propertyname, $this->getVersion());
+            }
+        } else {
+            // Raw task
+            $this->getProject()->setNewProperty($this->propertyname, $this->getVersion());
+        }
+    }
+
+    /**
+     * Evaluate the condition.
+     * @return true if the condition is true.
+     * @throws BuildException if an error occurs.
+     */
+    public function evaluate()
+    {
+        $this->validate();
+        $actual = $this->getVersion();
+        if (null != $this->atLeast) {
+            return version_compare($actual, $this->atLeast, '>=');
+        }
+
+        if (null != $this->exactly) {
+            return version_compare($actual, $this->exactly, '=');
+        }
+
+        return false;
+    }
+
+    private function validate()
+    {
+        if ($this->atLeast != null && $this->exactly != null) {
+            throw new BuildException("Only one of atleast or exactly may be set.");
+        }
+        if (null == $this->atLeast && null == $this->exactly) {
+            throw new BuildException("One of atleast or exactly must be set.");
+        }
+    }
+
+    private function getVersion()
+    {
+        $p = new Project();
+
+        return $p->getPhingVersion();
+    }
+
+    /**
+     * Get the atleast attribute.
+     * @return string the atleast attribute.
+     */
+    public function getAtLeast()
+    {
+        return $this->atLeast;
+    }
+
+    /**
+     * Set the atleast attribute.
+     * This is of the form major.minor.point.
+     * For example 1.7.0.
+     * @param string $atLeast the version to check against.
+     */
+    public function setAtLeast($atLeast)
+    {
+        $this->atLeast = $atLeast;
+    }
+
+    /**
+     * Get the exactly attribute.
+     * @return string the exactly attribute.
+     */
+    public function getExactly()
+    {
+        return $this->exactly;
+    }
+
+    /**
+     * Set the exactly attribute.
+     * This is of the form major.minor.point.
+     * For example 1.7.0.
+     * @param string $exactly the version to check against.
+     */
+    public function setExactly($exactly) {
+        $this->exactly = $exactly;
+    }
+
+    /**
+     * Get the name of the property to hold the phing version.
+     * @return string the name of the property.
+     */
+    public function getProperty()
+    {
+        return $this->propertyname;
+    }
+
+    /**
+     * Set the name of the property to hold the phing version.
+     * @param string $propertyname the name of the property.
+     */
+    public function setProperty($propertyname)
+    {
+        $this->propertyname = $propertyname;
+    }
+}

--- a/docs/docbook5/en/source/appendixes/coretasks.xml
+++ b/docs/docbook5/en/source/appendixes/coretasks.xml
@@ -2560,6 +2560,64 @@
             </itemizedlist>
         </sect2>
     </sect1>
+    <sect1 role="taskdef" xml:id="Phingversion">
+        <title>Phingversion</title>
+        <para> Stores the Phing version (when used as task) or checks for a specific Phing version
+            (when used as condition).
+        </para>
+        <table>
+            <title>Attributes</title>
+            <tgroup cols="5">
+                <colspec colname="name" colnum="1" colwidth="1.5*"/>
+                <colspec colname="type" colnum="2" colwidth="0.8*"/>
+                <colspec colname="description" colnum="3" colwidth="3.5*"/>
+                <colspec colname="requiredtask" colnum="4" colwidth="1.0*"/>
+                <colspec colname="requiredcond" colnum="5" colwidth="1.0*"/>
+                <thead>
+                    <row>
+                        <entry>Name</entry>
+                        <entry>Type</entry>
+                        <entry>Description</entry>
+                        <entry>Required (Task)</entry>
+                        <entry>Required (Condition)</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry><literal>atleast</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>The version that this at least. The format is <literal>major.minor.point</literal>.</entry>
+                        <entry>No</entry>
+                        <entry morerows="1" valign="middle"><para>One of these.</para></entry>
+                    </row>
+                    <row>
+                        <entry><literal>exactly</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>The version that this phing is exactly. The format is <literal>major.minor.point</literal>.</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry><literal>property</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>The name of the property to set.</entry>
+                        <entry>Yes</entry>
+                        <entry>No (ignored)</entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+        <sect2>
+            <title>Example</title>
+            <programlisting language="xml">&lt;phingversion property="phingversion"/></programlisting>
+            <para>Stores the current Phing version in the property <literal>phingversion</literal>.</para>
+            <programlisting language="xml">&lt;phingversion property="phingversion" atleast="2.9"/></programlisting>
+            <para>Stores the Phing version in the property <literal>phingversion</literal>
+                if the current Phing version is 2.9.0 or higher. Otherwise the property remains unset.</para>
+            <programlisting language="xml">&lt;phingversion property="phing-is-exact-292" exactly="2.9.2"/></programlisting>
+            <para>Sets the property <literal>phing-is-exact-292</literal> if Phing 2.9.2 is running. Neither 2.8.2 nor 2.9.1
+                would match.</para>
+        </sect2>
+    </sect1>
     <sect1 role="taskdef" xml:id="PhpEvalTask">
         <title>PhpEvalTask </title>
         <para>With the <literal>PhpEvalTask</literal>, you can set a property to the results of evaluating

--- a/test/classes/phing/tasks/condition/PhingVersionTest.php
+++ b/test/classes/phing/tasks/condition/PhingVersionTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+include_once 'phing/BuildFileTest.php';
+
+/**
+ * Testcase for the PhingVersion task/condition.
+ *
+ * @author    Siad Ardroumli <siad.ardroumli@gmail.com>
+ * @package phing.tasks.system.condition
+ */
+class PhingVersionTest extends BuildFileTest
+{
+    public function setUp()
+    {
+        $this->configureProject(
+            PHING_TEST_BASE . '/etc/tasks/system/PhingVersionTest.xml'
+        );
+    }
+
+    public function testPhingVersion()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $expectedVersion = $this->getProject()->getProperty('version1');
+        $this->assertPropertyEquals('version1', $expectedVersion);
+    }
+
+    public function testPhingVersionAtLeastPos()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $expectedVersion = $this->getProject()->getProperty('version2');
+        $this->assertPropertyEquals('version2', $expectedVersion);
+    }
+
+    public function testPhingVersionAtLeastNeg()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertPropertyUnset('version3');
+    }
+
+    public function testPhingVersionIsNotExact()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertPropertyUnset('version4');
+    }
+
+    public function testPhingVersionAsCondition()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertPropertySet('isTrue');
+    }
+}

--- a/test/etc/tasks/system/PhingVersionTest.xml
+++ b/test/etc/tasks/system/PhingVersionTest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="PhingVersionTest" default="testPhingVersion">
+    <target name="testPhingVersion">
+        <phingversion property="version1"/>
+    </target>
+    <target name="testPhingVersionAtLeastPos">
+        <phingversion property="version2" atleast="1.9"/>
+    </target>
+    <target name="testPhingVersionAtLeastNeg">
+        <phingversion property="version3" atleast="10.9"/>
+    </target>
+    <target name="testPhingVersionIsNotExact">
+        <phingversion property="version4" exactly="1.9.2"/>
+    </target>
+    <target name="testPhingVersionAsCondition">
+        <condition property="isTrue">
+            <and>
+                <phingversion property="version5" atleast="1.9"/>
+                <not>
+                    <phingversion property="version6" atleast="10.9"/>
+                </not>
+            </and>
+        </condition>
+    </target>
+</project>


### PR DESCRIPTION
Examples
```
    <phingversion property="phingversion"/>
```
Stores the current Phing version in the property phingversion.
```
    <phingversion property="phingversion" atleast="2.9"/>
```
Stores the Phing version in the property phingversion if the current Phing version is 2.9.0 or higher. Otherwise the property remains unset.
```
    <phingversion property="phing-is-exact" exactly="2.8.2-238-g0cde4a0"/>
```
Sets the property phing-is-exact if Phing 2.8.2-238-g0cde4a0 is running. Neither 2.8.0 nor 2.8.2 would match.
```
    <condition property="PhingisOnline">
      <and>
        <phingversion exactly="2.8.2-238-g0cde4a0"/>
        <http url="http://www.phing.info"/>
      </and>
    </condition>
```
Sets PhingisOnline if Phing 2.8.2-238-g0cde4a0 is running and can get a non-error-response from the Phing homepage.