### PR TITLE
Added support for status code on exit and updated FailTask.

### DIFF
--- a/classes/phing/BuildException.php
+++ b/classes/phing/BuildException.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  *  $Id$
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -26,7 +26,7 @@
  * @version  $Id$
  * @package  phing
  */
-class BuildException extends Exception
+class BuildException extends RuntimeException
 {
 
     /**
@@ -54,7 +54,7 @@ class BuildException extends Exception
      * @param Location|Exception|null $p2
      * @param Location|null           $p3
      */
-    public function __construct($p1, $p2 = null, $p3 = null)
+    public function __construct($p1 = "", $p2 = null, $p3 = null)
     {
 
         $cause = null;
@@ -126,5 +126,4 @@ class BuildException extends Exception
         $this->location = $loc;
         $this->message = $loc->toString() . ': ' . $this->message;
     }
-
 }

--- a/classes/phing/ExitStatusException.php
+++ b/classes/phing/ExitStatusException.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+/**
+ * BuildException + exit status.
+ *
+ * @author   Siad Ardroumli <siad.ardroumli@gmail.com>
+ * @package  phing
+ */
+class ExitStatusException extends BuildException
+{
+    /** Status code */
+    protected $code;
+
+    /**
+     * Constructs an <code>ExitStatusException</code>.
+     * @param null|int|string $arg1
+     * @param int $arg2
+     * @param Location $arg3
+     */
+    public function __construct($arg1 = null, $arg2 = 0, Location $arg3 = null)
+    {
+        $methodArgsNum = func_num_args();
+        if ($methodArgsNum === 1) {
+            parent::__construct();
+            $this->code = (int) $arg1;
+        } elseif ($methodArgsNum === 2 && is_string($arg1) && is_int($arg2)) {
+            parent::__construct($arg1);
+            $this->code = $arg2;
+        } elseif ($methodArgsNum === 3 && is_string($arg1) && is_int($arg2)) {
+            parent::__construct($arg1, $arg3);
+            $this->code = $arg2;
+        }
+    }
+}

--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -160,7 +160,9 @@ class Phing
             $m->execute($args);
         } catch (Exception $exc) {
             self::handleLogfile();
-            throw $exc;
+            self::printMessage($exc);
+            self::statusExit(1);
+            return;
         }
 
         if ($additionalUserProperties !== null) {
@@ -169,15 +171,40 @@ class Phing
             }
         }
 
+        // expect the worst
+        $exitCode = 1;
         try {
-            $m->runBuild();
+            try {
+                $m->runBuild();
+                $exitCode = 0;
+            } catch (ExitStatusException $ese) {
+                $exitCode = $ese->getCode();
+                if ($exitCode != 0) {
+                    self::handleLogfile();
+                    throw $ese;
+                }
+            }
+        } catch (BuildException $exc) {
+            // avoid printing output twice: self::printMessage($exc);
         } catch (Exception $exc) {
-            self::handleLogfile();
-            throw $exc;
-        }
+             echo $exc->getTraceAsString();
+             self::printMessage($exc);
+         }
 
         // everything fine, shutdown
         self::handleLogfile();
+        self::statusExit($exitCode);
+    }
+
+    /**
+     * This operation is expected to call `exit($int)`, which
+     * is what the base version does.
+     * However, it is possible to do something else.
+     * @param int $exitCode code to exit with
+     */
+    protected static function statusExit($exitCode)
+    {
+        exit($exitCode);
     }
 
     /**

--- a/classes/phing/tasks/system/FailTask.php
+++ b/classes/phing/tasks/system/FailTask.php
@@ -18,6 +18,7 @@
  */
 
 require_once 'phing/Task.php';
+require_once 'phing/ExitStatusException.php';
 
 /**
  * Exits the active build, giving an additional message
@@ -34,6 +35,8 @@ class FailTask extends Task
     protected $message;
     protected $ifCondition;
     protected $unlessCondition;
+    protected $nestedCondition;
+    protected $status;
 
     /**
      * A message giving further information on why the build exited.
@@ -85,6 +88,15 @@ class FailTask extends Task
     }
 
     /**
+     * Set the status code to associate with the thrown Exception.
+     * @param int $int the <code>int</code> status
+     */
+    public function setStatus($int)
+    {
+        $this->status = (int) $int;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return void
@@ -94,12 +106,51 @@ class FailTask extends Task
     public function main()
     {
         if ($this->testIfCondition() && $this->testUnlessCondition()) {
-            if ($this->message !== null) {
-                throw new BuildException($this->message);
+            $text = null;
+            if ($this->message !== null && strlen(trim($this->message)) > 0) {
+                $text = trim($this->message);
             } else {
-                throw new BuildException("No message");
+                if ($this->ifCondition !== null && $this->ifCondition !== "" && $this->testIfCondition()) {
+                    $text = "if=" . $this->ifCondition;
+                }
+                if ($this->unlessCondition !== null && $this->unlessCondition !== "" && $this->testUnlessCondition()) {
+                    if ($text === null) {
+                        $text = "";
+                    } else {
+                        $text .= " and ";
+                    }
+                    $text .= "unless=" . $this->unlessCondition;
+                }
+                if ($this->nestedConditionPresent()) {
+                    $text = "condition satisfied";
+                } else {
+                    if ($text === null) {
+                        $text = "No message";
+                    }
+                }
             }
+
+            $this->log("failing due to " . $text, Project::MSG_DEBUG);
+            if ($this->status === null) {
+                throw new BuildException($text);
+            }
+
+            throw new ExitStatusException($text, $this->status);
         }
+    }
+
+    /**
+     * Add a condition element.
+     * @return ConditionBase
+     * @throws BuildException
+     */
+    public function createCondition()
+    {
+        if ($this->nestedCondition !== null) {
+            throw new BuildException("Only one nested condition is allowed.");
+        }
+        $this->nestedCondition = new NestedCondition();
+        return $this->nestedCondition;
     }
 
     /**
@@ -139,5 +190,44 @@ class FailTask extends Task
         }
 
         return $this->project->getProperty($this->unlessCondition) === null;
+    }
+
+    /**
+     * test the nested condition
+     * @return bool true if there is none, or it evaluates to true
+     * @throws BuildException
+     */
+    private function testNestedCondition()
+    {
+        $result = $this->nestedConditionPresent();
+
+        if ($result && $this->ifCondition !== null || $this->unlessCondition !== null) {
+            throw new BuildException("Nested conditions not permitted in conjunction with if/unless attributes");
+        }
+
+        return $result && $this->nestedCondition->evaluate();
+    }
+
+    /**
+     * test whether there is a nested condition.
+     * @return boolean
+     */
+    private function nestedConditionPresent()
+    {
+        return (bool) $this->nestedCondition;
+    }
+}
+
+class NestedCondition extends ConditionBase implements Condition
+{
+    public function evaluate()
+    {
+        if ($this->countConditions() != 1) {
+            throw new BuildException(
+                "A single nested condition is required.");
+        }
+        $cond = $this->getConditions();
+
+        return $cond[0]->evaluate();
     }
 }

--- a/classes/phing/tasks/system/FailTask.php
+++ b/classes/phing/tasks/system/FailTask.php
@@ -19,6 +19,7 @@
 
 require_once 'phing/Task.php';
 require_once 'phing/ExitStatusException.php';
+require_once 'phing/tasks/system/condition/NestedCondition.php';
 
 /**
  * Exits the active build, giving an additional message
@@ -215,19 +216,5 @@ class FailTask extends Task
     private function nestedConditionPresent()
     {
         return (bool) $this->nestedCondition;
-    }
-}
-
-class NestedCondition extends ConditionBase implements Condition
-{
-    public function evaluate()
-    {
-        if ($this->countConditions() != 1) {
-            throw new BuildException(
-                "A single nested condition is required.");
-        }
-        $cond = $this->getConditions();
-
-        return $cond[0]->evaluate();
     }
 }

--- a/classes/phing/tasks/system/condition/NestedCondition.php
+++ b/classes/phing/tasks/system/condition/NestedCondition.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+require_once 'phing/tasks/system/condition/Condition.php';
+require_once 'phing/tasks/system/condition/ConditionBase.php';
+
+/**
+ * Nested conditions.
+ *
+ * @author    Siad Ardroumli <siad.ardroumli@gmail.com>
+ * @package   phing.tasks.system.condition
+ */
+class NestedCondition extends ConditionBase implements Condition
+{
+    public function evaluate()
+    {
+        if ($this->countConditions() != 1) {
+            throw new BuildException(
+                "A single nested condition is required.");
+        }
+        $cond = $this->getConditions();
+
+        return $cond[0]->evaluate();
+    }
+}

--- a/docs/docbook5/en/source/appendixes/coretasks.xml
+++ b/docs/docbook5/en/source/appendixes/coretasks.xml
@@ -1751,6 +1751,14 @@
                         <entry>n/a</entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>status</literal></entry>
+                        <entry><literal role="type">Integer</literal></entry>
+                        <entry>Exit using the specified status code; assuming the generated Exception is not caught,
+                            PHP will exit with this status.</entry>
+                        <entry>n/a</entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -1763,7 +1771,23 @@
 &lt;fail if="errorprop" message="Detected error!" />
 
 &lt;!-- Exit unless ${dontfail} prop is defined. -->
-&lt;fail unless="dontfail" message="Detected error!" /></programlisting>
+&lt;fail unless="dontfail" message="Detected error!" />
+
+&lt;!-- Using a condition to achieve the same effect:
+&lt;fail message="Detected error!">
+    &lt;condition>
+        &lt;not>
+            &lt;isset property="dontfail"/>
+        &lt;/not>
+    &lt;/condition>
+&lt;/fail></programlisting>
+        </sect2>
+        <sect2 role="nestedtags">
+            <title>Parameters specified as nested elements.</title>
+            <para>As an alternative to the <literal>if/unless</literal> attributes, conditional failure can be achieved
+                using a single nested <literal>&lt;condition></literal> element,
+                which should contain exactly one core or custom condition.
+            </para>
         </sect2>
     </sect1>
 


### PR DESCRIPTION
Extends phing with status code on shutdown and updated FailTask to support status flag and nested condition.
Example:
```
<fail status="255">
    <condition>
        <not>
            <isset property="thisdoesnotexist"/>
        </not>
    </condition>
</fail>
```
