### PR TITLE
Make basedir property (including its default value) a path relative to the buildfile

### DIFF
--- a/docs/docbook5/en/source/chapters/gettingstarted.xml
+++ b/docs/docbook5/en/source/chapters/gettingstarted.xml
@@ -154,10 +154,12 @@
                         </row>
                         <row>
                             <entry><literal>basedir</literal></entry>
-                            <entry>The base directory of the project, use &quot;.&quot; do denote
-                                the current directory. <emphasis role="bold">Note:</emphasis> if
-                                none is specified, the parent directory of the build file is
-                                used!</entry>
+                            <entry>The base directory of the project. This attribute controls the value of the
+                                <literal>${project.basedir}</literal> property which can be used to reference
+                                files with paths relative to the project root folder. Can be a path relative to
+                                the position of the buildfile itself. If omitted, &quot;.&quot; will be used,
+                                which means that the build file should be located in the project's root folder.
+                            </entry>
                             <entry>No</entry>
                         </row>
                         <row>

--- a/src/Parser/ProjectHandler.php
+++ b/src/Parser/ProjectHandler.php
@@ -151,7 +151,7 @@ class ProjectHandler extends AbstractHandler
                 if ($f->isAbsolute()) {
                     $project->setBasedir($baseDir);
                 } else {
-                    $project->setBaseDir($project->resolveFile($baseDir, new File(getcwd())));
+                    $project->setBaseDir($project->resolveFile($baseDir, $buildFileParent));
                 }
             }
         }

--- a/test/classes/phing/regression/309/Ticket309RegressionTest.php
+++ b/test/classes/phing/regression/309/Ticket309RegressionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use \Phing\Test\AbstractBuildFileTest;
+
+class Ticket309RegressionTest extends AbstractBuildFileTest {
+
+    /**
+     * The project.basedir property denotes the project root directory.
+     * This root directory can be set by the "basedir" attribute on the
+     * <project> tag. It denotes the path to the project root, relative to
+     * the buildfile.
+     *
+     * The default is ".", meaning that the build.xml file is locate in the
+     * project root.
+     *
+     * This test uses several buildfiles that reference the /etc/regression/309
+     * directory as their project root in various ways.
+     */
+    public function testPhingCallTask()
+    {
+        $testBasedir = PHING_TEST_BASE . "/etc/regression/309";
+
+        foreach (array('basedir-dot.xml', 'basedir-default.xml', 'sub/basedir-dotdot.xml') as $buildfile) {
+            $this->configureProject("$testBasedir/$buildfile");
+            $this->executeTarget("main");
+            $this->assertInLogs("project.basedir: $testBasedir");
+        }
+    }
+
+} 

--- a/test/etc/regression/309/basedir-default.xml
+++ b/test/etc/regression/309/basedir-default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<project name="test" default="main">
+
+    <target name="main">
+        <echo>project.basedir: ${project.basedir}</echo>
+        <echo>application.startdir: ${application.startdir}</echo>
+    </target>
+
+</project>

--- a/test/etc/regression/309/basedir-dot.xml
+++ b/test/etc/regression/309/basedir-dot.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<project name="test" default="main" basedir=".">
+
+    <target name="main">
+        <echo>project.basedir: ${project.basedir}</echo>
+        <echo>application.startdir: ${application.startdir}</echo>
+    </target>
+
+</project>

--- a/test/etc/regression/309/sub/basedir-dotdot.xml
+++ b/test/etc/regression/309/sub/basedir-dotdot.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<project name="test" default="main" basedir="..">
+
+    <target name="main">
+        <echo>project.basedir: ${project.basedir}</echo>
+        <echo>application.startdir: ${application.startdir}</echo>
+    </target>
+
+</project>


### PR DESCRIPTION
See http://www.phing.info/trac/ticket/309

This might be considered a BC break. Acutally it reverts behaviour to what it was many moons ago.
The fix was (IMO) wrong in the first place, improved docs (including docbook) instead.

(cherry-picking eaf81bc316ed965f4d57b66c75a65e5dbf9e0c8c off unstable-3.0)
(This also obsoletes #243)