### PR TITLE
Add regressions tests for the changes intended by trac-620

### DIFF
--- a/docs/docbook5/en/source/appendixes/coretasks.xml
+++ b/docs/docbook5/en/source/appendixes/coretasks.xml
@@ -2031,7 +2031,7 @@
                 The right way to use <literal>imported.properties</literal> is:</para>
             <programlisting language="xml">&lt;!-- imported.xml -->
 &lt;project name="imported" basedir="." default="...">
-  &lt;property file="${phing.basedir.imported}/imported.properties"/>
+  &lt;property file="${project.basedir.imported}/imported.properties"/>
 &lt;/project></programlisting>
             <para>As explained above <literal>${phing.file.imported}</literal> stores the full path of the build
                 script, that defines the project called <emphasis>imported</emphasis>, (in short it

--- a/src/Parser/ProjectHandler.php
+++ b/src/Parser/ProjectHandler.php
@@ -125,7 +125,7 @@ class ProjectHandler extends AbstractHandler
         $path = (string)$this->configurator->getBuildFile();
         $project->setUserProperty("phing.file.{$canonicalName}", $path);
         $project->setUserProperty("phing.dir.{$canonicalName}", dirname($path));
-        $project->setUserProperty("phing.basedir.{$canonicalName}", $resolvedBasedir);
+        $project->setUserProperty("project.basedir.{$canonicalName}", $resolvedBasedir);
 
         if ($this->configurator->isIgnoringProjectTag()) {
             return;

--- a/test/classes/phing/regression/620/Ticket620RegressionTest.php
+++ b/test/classes/phing/regression/620/Ticket620RegressionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Phing\Test\AbstractBuildFileTest;
+
+class Ticket620RegressionTest extends AbstractBuildFileTest
+{
+
+    public function testCallingImportedBuildfileUsesOwnTarget()
+    {
+        $this->configureProject(PHING_TEST_BASE . "/etc/regression/620/subdir/imported.xml");
+        $this->executeTarget("test");
+        $this->assertInLogs("imported.xml::some-target");
+    }
+
+    public function testCallingImportingBuildfileOverridesTarget()
+    {
+        $this->configureProject(PHING_TEST_BASE . "/etc/regression/620/importing.xml");
+        $this->executeTarget("test"); // defined in the "imported.xml" buildfile
+        $this->assertInLogs("importing.xml::some-target"); // "some-target" overridden by importing.xml
+    }
+
+    public function testOverriddenTargetAvailableUnderAliasName()
+    {
+        $this->configureProject(PHING_TEST_BASE . "/etc/regression/620/importing.xml");
+        $this->executeTarget("use-aliased-target"); // this target depends on "imported.some-target"
+        $this->assertInLogs("imported.xml::some-target");
+    }
+
+    public function testProperties()
+    {
+        /*
+         * The properties phing.file, phing.dir and project.basedir point to the
+         * buildfile, directory containing the buildfile and project basedir referenced
+         * by the "root" (executed) buildfile, respectively.
+         *
+         * These properties are also set with a ".[projectname]" suffix for the
+         * root and all imported buildfiles, where "[projectname]" is the <project> @name
+         * attribute for each respective buildfile.
+         *
+         * Note that subdir/imported.xml refers to ".." as basedir.
+         */
+        $this->configureProject(PHING_TEST_BASE . "/etc/regression/620/importing.xml");
+        $this->executeTarget("dump-properties");
+
+        // The "main" buildfile
+        $this->assertInLogs("project.basedir = ".PHING_TEST_BASE."/etc/regression/620");
+        $this->assertInLogs("phing.file = ".PHING_TEST_BASE."/etc/regression/620/importing.xml");
+        $this->assertInLogs("phing.dir = ".PHING_TEST_BASE."/etc/regression/620");
+
+        // Same as for the "main" buildfile, but under its projectname
+        $this->assertInLogs("project.basedir.importing = ".PHING_TEST_BASE."/etc/regression/620");
+        $this->assertInLogs("phing.file.importing = ".PHING_TEST_BASE."/etc/regression/620/importing.xml");
+        $this->assertInLogs("phing.dir.importing = ".PHING_TEST_BASE."/etc/regression/620");
+
+        // Values for the "imported" buildfile
+        $this->assertInLogs("project.basedir.imported = ".PHING_TEST_BASE."/etc/regression/620");
+        $this->assertInLogs("phing.file.imported = ".PHING_TEST_BASE."/etc/regression/620/subdir/imported.xml");
+        $this->assertInLogs("phing.dir.imported = ".PHING_TEST_BASE."/etc/regression/620/subdir");
+    }
+
+}

--- a/test/etc/regression/620/importing.xml
+++ b/test/etc/regression/620/importing.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<project name="importing" default="test">
+
+    <import file="subdir/imported.xml" />
+
+    <!-- The "test" target is contained in the imported buildfile only. -->
+
+    <target name="some-target">
+        <echo>Target "some-target" in the importing.xml buildfile.</echo>
+        <echo>importing.xml::some-target</echo>
+    </target>
+
+    <target name="use-aliased-target" depends="imported.some-target">
+        <echo>
+            This target depends on "imported.some-target". This aliased
+            name is created for "some-target" imported from imported.xml
+            and allows to call this target explicitly. Remember, the "some-target"
+            has been overridden/hidden by "some-target" in this buildfile.
+        </echo>
+    </target>
+
+    <target name="dump-properties">
+        <echo>project.basedir = ${project.basedir}</echo>
+        <echo>phing.file = ${phing.file}</echo>
+        <echo>phing.dir = ${phing.dir}</echo>
+        <echo>project.basedir.importing = ${project.basedir.importing}</echo>
+        <echo>phing.file.importing = ${phing.file.importing}</echo>
+        <echo>phing.dir.importing = ${phing.dir.importing}</echo>
+        <echo>project.basedir.imported = ${project.basedir.imported}</echo>
+        <echo>phing.file.imported = ${phing.file.imported}</echo>
+        <echo>phing.dir.imported = ${phing.dir.imported}</echo>
+    </target>
+
+</project>

--- a/test/etc/regression/620/subdir/imported.xml
+++ b/test/etc/regression/620/subdir/imported.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<project name="imported" default="test" basedir="..">
+
+    <target name="some-target">
+        <echo>Target "some-target" in the imported.xml buildfile.</echo>
+        <echo>imported.xml::some-target</echo>
+    </target>
+
+    <target name="test" depends="some-target">
+        <echo>
+            This target depends on "some-target". When this buildfile is
+            called directly, "some-target" in imported.xml will be run.
+
+            When this buildfile is imported from another buildfile that
+            overrides "some-target", the other implementation will be called
+            instead.
+        </echo>
+    </target>
+
+</project>


### PR DESCRIPTION
Here are some tests that cover the changes intended by or at least documented in http://www.phing.info/trac/ticket/620.

The tests are currently *not* passing. In particular, there's still a problem with the various properties that need to be set for the imported buildfile.

This is the output for the current `3.0` version of `phing` (on my machine):

```
~/Projekte/phing/test$ ../bin/phing -f etc/regression/620/importing.xml dump-properties
Buildfile: /Users/mp/Projekte/phing/test/etc/regression/620/importing.xml

importing > dump-properties:

     [echo] project.basedir = /Users/mp/Projekte/phing/test/etc/regression/620
     [echo] phing.file = /Users/mp/Projekte/phing/test/etc/regression/620/importing.xml
     [echo] phing.dir = /Users/mp/Projekte/phing/test/etc/regression/620
     [echo] project.basedir.importing = ${project.basedir.importing}
     [echo] phing.file.importing = /Users/mp/Projekte/phing/test/etc/regression/620/importing.xml
     [echo] phing.dir.importing = /Users/mp/Projekte/phing/test/etc/regression/620
     [echo] project.basedir.imported = ${project.basedir.imported}
     [echo] phing.file.imported = /Users/mp/Projekte/phing/test/etc/regression/620/subdir/imported.xml
     [echo] phing.dir.imported = /Users/mp/Projekte/phing/test/etc/regression/620/subdir

BUILD FINISHED

Total time: 0.1627 seconds
```

*The project.basedir.[projectname] property is currently missing on the 3.0 branch.*

And here's the `unstable-3.0` version of `phing`:

```
mp@silverbook:~/Projekte/phing/test$ phing -f etc/regression/620/importing.xml dump-properties
Buildfile: /Users/mp/Projekte/phing/test/etc/regression/620/importing.xml

importing > dump-properties:

     [echo] project.basedir = /Users/mp/Projekte/phing/test/etc/regression/620
     [echo] phing.file = /Users/mp/Projekte/phing/test/etc/regression/620/importing.xml
     [echo] phing.dir = ${phing.dir}
     [echo] project.basedir.importing = /Users/mp/Projekte/phing/test/etc/regression/620
     [echo] phing.file.importing = /Users/mp/Projekte/phing/test/etc/regression/620/importing.xml
     [echo] phing.dir.importing = ${phing.dir.importing}
     [echo] project.basedir.imported = /Users/mp/Projekte/phing/test/etc/regression/620
     [echo] phing.file.imported = /Users/mp/Projekte/phing/test/etc/regression/620/subdir/imported.xml
     [echo] phing.dir.imported = ${phing.dir.imported}

BUILD FINISHED

Total time: 0.1124 seconds
```

I would not try to figure out why the `phing.dir[.*]` is missing there. But this output shows that the `project.basedir.*` property has been working on `unstable-3.0` and was probably lost during the rebase/cherry-pick.