### PR TITLE
Fixed call to createDate in MatchingTask

### DIFF
--- a/classes/phing/tasks/system/MatchingTask.php
+++ b/classes/phing/tasks/system/MatchingTask.php
@@ -323,7 +323,7 @@ abstract class MatchingTask extends Task implements SelectorContainer
      */
     public function createDate()
     {
-        return $this->fileset->addDate();
+        return $this->fileset->createDate();
     }
 
     /**


### PR DESCRIPTION
`AbstractFileSet::addDate` does not exist so it should be `AbstractFileSet::createDate` instead.