### PR TITLE
Simplify UpToDateTask

### DIFF
--- a/classes/phing/tasks/system/UpToDateTask.php
+++ b/classes/phing/tasks/system/UpToDateTask.php
@@ -255,11 +255,7 @@ class UpToDateTask extends Task implements Condition
         }
         $upToDate = $this->evaluate();
         if ($upToDate) {
-            $property = $this->project->createTask('property');
-            $property->setName($this->getProperty());
-            $property->setValue($this->getValue());
-            $property->setOverride(true);
-            $property->main(); // execute
+            $this->project->setProperty($this->getProperty(), $this->getValue());
 
             if ($this->mapperElement === null) {
                 $this->log(


### PR DESCRIPTION
We don't really want to dispatch an entire subtask here, do we?

The downside is that if you set the target property as a user property (e. g. on the command line), chances are that your user property will win and you don't see the updated value.

But hey, that's how user properties work.
