### PR TITLE
Fix PhpCodeSniffer task for version 2.2. (compatible with older versions)

### DIFF
--- a/classes/phing/tasks/ext/PhpCodeSnifferTask.php
+++ b/classes/phing/tasks/ext/PhpCodeSnifferTask.php
@@ -531,7 +531,7 @@ class PhpCodeSnifferTask extends Task
 
             // Crude check, but they broke backwards compatibility
             // with a minor version release.
-            if ($phpcs::VERSION >= '2.2.0') {
+            if (PHP_CodeSniffer::VERSION >= '2.2.0') {
                 $cliValues = array('colors' => false);
                 $reporting->printReport($fe->getType(),
                                         $this->showSources,

--- a/classes/phing/tasks/ext/PhpCodeSnifferTask.php
+++ b/classes/phing/tasks/ext/PhpCodeSnifferTask.php
@@ -529,12 +529,21 @@ class PhpCodeSnifferTask extends Task
                 //ob_start();
             }
 
-            $reporting->printReport(
-                $fe->getType(),
-                $this->showSources,
-                $reportFile,
-                $this->reportWidth
-            );
+            // Crude check, but they broke backwards compatibility
+            // with a minor version release.
+            if ($phpcs::VERSION >= '2.2.0') {
+                $cliValues = array('colors' => false);
+                $reporting->printReport($fe->getType(),
+                                        $this->showSources,
+                                        $cliValues,
+                                        $reportFile,
+                                        $this->reportWidth);
+            } else {
+                $reporting->printReport($fe->getType(),
+                                        $this->showSources,
+                                        $reportFile,
+                                        $this->reportWidth);
+            }
 
             // reporting class uses ob_end_flush(), but we don't want
             // an output if we use a file

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	"pear-pear.php.net/PEAR_PackageFileManager": "1.7.x",
 	"pear-pear.php.net/PEAR_PackageFileManager2": "1.0.x",
 	"pear-pear.php.net/XML_Serializer": "0.20.x",
-	"squizlabs/php_codesniffer": "1.5.x",
+	"squizlabs/php_codesniffer": "~2.2",
 	"lastcraft/simpletest": "@dev",
 	"ext-pdo_sqlite": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "273fb3104a143f4e75669d8057140625",
+    "hash": "1363f1c0a59b2bc46b780f5fe1569d4a",
     "packages": [],
     "packages-dev": [
         {
@@ -3236,46 +3236,39 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "1.5.6",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6f3e42d311b882b25b4d409d23a289f4d3b803d5"
+                "reference": "b301c98f19414d836fdaa678648745fcca5aeb4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6f3e42d311b882b25b4d409d23a289f4d3b803d5",
-                "reference": "6f3e42d311b882b25b4d409d23a289f4d3b803d5",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b301c98f19414d836fdaa678648745fcca5aeb4f",
+                "reference": "b301c98f19414d836fdaa678648745fcca5aeb4f",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
                 "php": ">=5.1.2"
             },
-            "suggest": {
-                "phpunit/php-timer": "dev-master"
-            },
             "bin": [
-                "scripts/phpcs"
+                "scripts/phpcs",
+                "scripts/phpcbf"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-phpcs-fixer": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "classmap": [
                     "CodeSniffer.php",
                     "CodeSniffer/CLI.php",
                     "CodeSniffer/Exception.php",
                     "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
                     "CodeSniffer/Report.php",
                     "CodeSniffer/Reporting.php",
                     "CodeSniffer/Sniff.php",
                     "CodeSniffer/Tokens.php",
                     "CodeSniffer/Reports/",
-                    "CodeSniffer/CommentParser/",
                     "CodeSniffer/Tokenizers/",
                     "CodeSniffer/DocGenerators/",
                     "CodeSniffer/Standards/AbstractPatternSniff.php",
@@ -3301,13 +3294,13 @@
                     "role": "lead"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
             "homepage": "http://www.squizlabs.com/php-codesniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-04 22:32:15"
+            "time": "2015-01-21 22:44:05"
         },
         {
             "name": "symfony/config",
@@ -4634,6 +4627,7 @@
         "lastcraft/simpletest": 20
     },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.2.0"
     },


### PR DESCRIPTION
It involves a crude version check, but this maintains compatibility for older versions of PhpCodeSniffer.