### PR TITLE
Add PropertySet::prefix() method to extract properties with a common prefix

### DIFF
--- a/src/Util/Properties/PropertySet.php
+++ b/src/Util/Properties/PropertySet.php
@@ -24,4 +24,14 @@ namespace Phing\Util\Properties;
 interface PropertySet extends \ArrayAccess, \IteratorAggregate {
 	public function isEmpty();
 	public function keys();
+
+    /**
+     * Finds all properties that start with a given prefix, strips it
+     * and returns a new PropertySet instance.
+     *
+     * @param $prefix The prefix to find. A "." will be appended if not already present.
+     *
+     * @return PropertySet A PropertySet that contains the matching properties, with the prefix removed.
+     */
+    public function prefix($prefix);
 } 

--- a/src/Util/Properties/PropertySetImpl.php
+++ b/src/Util/Properties/PropertySetImpl.php
@@ -102,4 +102,22 @@ class PropertySetImpl implements PropertySet
     {
         return empty($this->p);
     }
+
+    public function prefix($prefix)
+    {
+        if (substr($prefix, -1) !== '.') {
+            $prefix .= '.';
+        }
+
+        $propertySet = new self();
+        $len = strlen($prefix);
+
+        foreach ($this->p as $key => $value) {
+            if (strpos($key, $prefix) === 0) {
+                $propertySet->p[substr($key, $len)] = $value;
+            }
+        }
+
+        return $propertySet;
+    }
 }

--- a/test/Util/Properties/PropertySetImplTest.php
+++ b/test/Util/Properties/PropertySetImplTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Phing\Tests\Util\Properties;
+
+use Phing\Util\Properties\PropertySetImpl;
+
+class PropertySetImplTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFindPrefix()
+    {
+        $base = new PropertySetImpl();
+        $base['foo.one'] = 1;
+        $base['foo.two'] = 2;
+        $base['bar'] = 42;
+
+        $fooOnly = $base->prefix('foo');
+
+        $this->assertTrue(isset($fooOnly['one']));
+        $this->assertEquals(1, $fooOnly['one']);
+        $this->assertFalse(isset($fooOnly['foo.one']));
+        $this->assertFalse(isset($fooOnly['bar']));
+    }
+}


### PR DESCRIPTION
This cherry-picks from 616e19b3e17c7d51fba8acbff0ef53211fe33c2c and fb61ebe8960970d591c2943b3d1c1b3656d3cac5.