### PR TITLE
Removed type cast to boolean.

### DIFF
--- a/classes/phing/system/io/Win32FileSystem.php
+++ b/classes/phing/system/io/Win32FileSystem.php
@@ -586,14 +586,14 @@ class Win32FileSystem extends FileSystem
     /** compares file paths lexicographically
      * @param PhingFile $f1
      * @param PhingFile $f2
-     * @return bool|void
+     * @return int
      */
     public function compare(PhingFile $f1, PhingFile $f2)
     {
         $f1Path = $f1->getPath();
         $f2Path = $f2->getPath();
 
-        return (boolean) strcasecmp((string) $f1Path, (string) $f2Path);
+        return strcasecmp((string) $f1Path, (string) $f2Path);
     }
 
     /**


### PR DESCRIPTION
Just to have the same result behavior as for the `UnixFileSytem::compare()`