### PR TITLE
Added optional algorithm attribute to FileHashTask

### DIFF
--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -907,6 +907,8 @@
         <title>FileHashTask</title>
         <para>Calculates either MD5 or SHA1 hash value of a file and stores the value as a hex
             string in a property.</para>
+        <para>Other popular <link xlink:href="http://php.net/manual/en/function.hash-algos.php">algorithms</link>
+            like "crc32" or "sha512" may be used with help of the <literal>algorithm</literal> attribute.</para>
         <table>
             <title>Attributes</title>
             <tgroup cols="5">
@@ -937,6 +939,15 @@
                         <entry><literal role="type">Integer</literal></entry>
                         <entry>Specifies what hash algorithm to use. 0=MD5, 1=SHA1</entry>
                         <entry>0</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry><literal>algorithm</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Specifies what hash algorithm to use. Supported
+                            <link xlink:href="http://php.net/manual/en/function.hash-algos.php">algorithms</link>.
+                        </entry>
+                        <entry>n/a</entry>
                         <entry>No</entry>
                     </row>
                     <row>

--- a/test/classes/phing/tasks/ext/FileHashTaskTest.php
+++ b/test/classes/phing/tasks/ext/FileHashTaskTest.php
@@ -43,4 +43,9 @@ class FileHashTaskTest extends BuildFileTest
     {
         $this->expectLog("testSHA1", "dadd0aafb79d9fb8299a928efb23c112874bbda3");
     }
+
+    public function testCRC32()
+    {
+        $this->expectLog("testCRC32", "d34c2e86");
+    }
 }

--- a/test/etc/tasks/ext/filehash.xml
+++ b/test/etc/tasks/ext/filehash.xml
@@ -11,6 +11,12 @@
     	hashtype="1"/>
    	<echo>${filehash.sha1}</echo>
     </target>
+
+	<target name="testCRC32">
+		<filehash file="filehash.bin" propertyName="filehash.crc32"
+				  algorithm="crc32"/>
+		<echo>${filehash.crc32}</echo>
+	</target>
     
-    <target name="build" depends="testMD5,testSHA1"/>
+    <target name="build" depends="testMD5,testSHA1,testCRC32"/>
 </project>


### PR DESCRIPTION
Added optional algorithm attribute to support more hashtypes.
Example:
```
<filehash file="filehash.bin" propertyName="filehash.crc32" algorithm="crc32"/>
<echo>${filehash.crc32}</echo>
```
