### PR TITLE
Fix: "Fatal error: Class 'PHP_PMD_RENDERER_XMLRenderer' not found"

### DIFF
--- a/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
+++ b/classes/phing/tasks/ext/phpmd/PHPMDFormatterElement.php
@@ -151,7 +151,7 @@ class PHPMDFormatterElement
         if (!class_exists('\\PHPMD\\Writer\\StreamWriter')) {
             $renderClass = 'PHP_PMD_RENDERER_' . $this->className;
             $writerClass = 'PHP_PMD_Writer_Stream';
-            include_once 'PHP/PPMD/Renderer/' . $this->className . '.php';
+            include_once 'PHP/PMD/Renderer/' . $this->className . '.php';
             include_once 'PHP/PMD/Writer/Stream.php';
         } else {
             $renderClass = 'PHPMD\Renderer\\' . $this->className;


### PR DESCRIPTION
It's PMD instead PPMD ;-). Fix: [PHP Error] include_once(PHP/PPMD/Renderer/XMLRenderer.php): failed to open stream: No such file or directory.