### PR TITLE
Solve ticket #1134 and add color support for all platforms

### DIFF
--- a/bin/pear-phing
+++ b/bin/pear-phing
@@ -15,4 +15,4 @@ if (test -z "$PHP_COMMAND") ; then
 	export PHP_COMMAND
 fi
 
-$PHP_COMMAND -d phar.readonly=off -d html_errors=off -qC @PEAR-DIR@/phing.php -logger phing.listener.AnsiColorLogger "$@"
+$PHP_COMMAND -d phar.readonly=off -d html_errors=off -qC @PEAR-DIR@/phing.php "$@"

--- a/bin/phing
+++ b/bin/phing
@@ -9,12 +9,6 @@
 // turn off html errors
 ini_set('html_errors', 'off');
 
-// default logger
-if (!in_array('-logger', $argv)) {
-    $argv[] = '-logger';
-    $argv[] = 'phing.listener.AnsiColorLogger';
-}
-
 putenv("PHING_HOME=" . realpath(dirname(__FILE__) . '/../'));
 
 require_once dirname(__FILE__) . '/phing.php';

--- a/bin/phing.php
+++ b/bin/phing.php
@@ -26,6 +26,23 @@ set_include_path(
 
 require_once 'phing/Phing.php';
 
+/**
+* Code from Symfony/Component/Console/Output/StreamOutput.php
+*/
+function hasColorSupport()
+{
+    if (DIRECTORY_SEPARATOR == '\\') {
+        return false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI');
+    }
+    return function_exists('posix_isatty') && @posix_isatty(STDOUT);
+}
+
+// default logger
+if (!in_array('-logger', $argv) && hasColorSupport()) {
+    $argv[] = '-logger';
+    $argv[] = 'phing.listener.AnsiColorLogger';
+}
+
 try {
 
     /* Setup Phing environment */

--- a/build/phing-stub.php
+++ b/build/phing-stub.php
@@ -1,13 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-if (DIRECTORY_SEPARATOR != '\\' && function_exists('posix_isatty') && @posix_isatty(STDOUT)) {
-    array_push($argv, '-logger');
-    array_push($argv, 'phing.listener.AnsiColorLogger');
-    $argc+=2;
-}
-$argc++;
-
 try {
     Phar::mapPhar('phing.phar');
     include 'phar://phing.phar/bin/phing.php';


### PR DESCRIPTION
I've removed `-logger` in `bin/pear-phing` and `bin/phing` and add it in a common and unique entry `bin/phing.php` which is called by all sources (including `bin/pear-phing.bat` and `bin/phing.bat`).

The default is then `phing.listener.AnsiColorLogger` is color is supported and if no `-logger` provided.
