### PR TITLE
Fixed "Cannot redeclare class PHP_PMD_RuleSetFactory" in the phpmd task.

### DIFF
--- a/classes/phing/tasks/ext/phpmd/PHPMDTask.php
+++ b/classes/phing/tasks/ext/phpmd/PHPMDTask.php
@@ -271,7 +271,9 @@ class PHPMDTask extends Task
             $ruleSetFactory = new $ruleSetClass(); //php 5.2 parser compatability
 
         } else {
-            @include 'PHP/PMD/RuleSetFactory.php';
+            if (!class_exists("PHP_PMD_RuleSetFactory")) {
+                @include 'PHP/PMD/RuleSetFactory.php';
+            }
             $ruleSetFactory = new PHP_PMD_RuleSetFactory();
         }
         $ruleSetFactory->setMinimumPriority($this->minimumPriority);


### PR DESCRIPTION
This was happening silently and causing phing to crash when phpmd is installed via composer.