### PR TITLE
Added Crap4jPHPUnitResultFormatter

### DIFF
--- a/classes/phing/tasks/ext/phpunit/FormatterElement.php
+++ b/classes/phing/tasks/ext/phpunit/FormatterElement.php
@@ -166,6 +166,9 @@ class FormatterElement
         } elseif ($this->type == "plain") {
             require_once 'phing/tasks/ext/phpunit/formatter/PlainPHPUnitResultFormatter.php';
             $this->formatter = new PlainPHPUnitResultFormatter($this->parent);
+        } elseif ($this->type == "crap4j") {
+            require_once 'phing/tasks/ext/phpunit/formatter/Crap4jPHPUnitResultFormatter.php';
+            $this->formatter = new Crap4jPHPUnitResultFormatter($this->parent);
         } else {
             throw new BuildException("Formatter '" . $this->type . "' not implemented");
         }

--- a/classes/phing/tasks/ext/phpunit/formatter/Crap4jPHPUnitResultFormatter.php
+++ b/classes/phing/tasks/ext/phpunit/formatter/Crap4jPHPUnitResultFormatter.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+require_once 'phing/tasks/ext/phpunit/formatter/PHPUnitResultFormatter.php';
+/**
+ * Prints Clover XML output of the test
+ *
+ * @author Daniel Kreckel <daniel@kreckel.koeln>
+ * @version $Id$
+ * @package phing.tasks.ext.formatter
+ * @since 2.1.1
+ */
+class Crap4jPHPUnitResultFormatter extends PHPUnitResultFormatter
+{
+    /**
+     * @var PHPUnit_Framework_TestResult
+     */
+    private $result = null;
+    /**
+     * PHPUnit version
+     * @var string
+     */
+    private $version = null;
+    /**
+     * @param PHPUnitTask $parentTask
+     */
+    public function __construct(PHPUnitTask $parentTask)
+    {
+        parent::__construct($parentTask);
+        $this->version = PHPUnit_Runner_Version::id();
+    }
+    /**
+     * @return string
+     */
+    public function getExtension()
+    {
+        return ".xml";
+    }
+    /**
+     * @return string
+     */
+    public function getPreferredOutfile()
+    {
+        return "crap4j-coverage";
+    }
+	
+    /**
+     * @param PHPUnit_Framework_TestResult $result
+     */
+    public function processResult(PHPUnit_Framework_TestResult $result)
+    {
+        $this->result = $result;
+    }
+	
+    public function endTestRun()
+    {
+        $coverage = $this->result->getCodeCoverage();
+        if (!empty($coverage)) {
+            $crap = new PHP_CodeCoverage_Report_Crap4j();
+            $contents = $crap->process($coverage);
+            if ($this->out) {
+                $this->out->write($contents);
+                $this->out->close();
+            }
+        }
+        parent::endTestRun();
+    }
+}


### PR DESCRIPTION
PHPUnit has build in the Crap4j-Report for over a year now.
Its really easy to bring it to phing.


Example:
```xml
<phpunit codecoverage="true">
    <formatter type="xml" todir="reports" />
    <formatter type="plain" todir="reports" />
    <formatter type="clover" todir="reports" />
    <formatter type="crap4j" todir="reports" />
    <batchtest>
        <fileset dir="tests">
            <include name="**/*Test*.php"/>
        </fileset>
    </batchtest>
</phpunit> 
```