### PR TITLE
Don't apply preg_quote to subject

### DIFF
--- a/classes/phing/tasks/ext/property/RegexTask.php
+++ b/classes/phing/tasks/ext/property/RegexTask.php
@@ -85,7 +85,7 @@ class RegexTask extends AbstractPropertySetterTask
      */
     public function setSubject($subject)
     {
-        $this->subject = preg_quote($subject, $this->delimiter);
+        $this->subject = $subject;
     }
 
     /**


### PR DESCRIPTION
This function add backslashes to characters in string, preventing to use $ in pattern for start by regex.
Additionally it adds \ to version numbers like 1.2.3 (becomes 1\.2\.3)