### PR TITLE
Integrate new NotifySendTask

### DIFF
--- a/classes/phing/tasks/defaults.properties
+++ b/classes/phing/tasks/defaults.properties
@@ -160,6 +160,7 @@ liquibase-rollback=phing.tasks.ext.liquibase.LiquibaseRollbackTask
 liquibase-tag=phing.tasks.ext.liquibase.LiquibaseTagTask
 liquibase-update=phing.tasks.ext.liquibase.LiquibaseUpdateTask
 liquibase=phing.tasks.ext.liquibase.LiquibaseTask
+notifysend=phing.tasks.ext.NotifySendTask
 growlnotify=phing.tasks.ext.GrowlNotifyTask
 wikipublish=phing.tasks.ext.WikiPublishTask
 stopwatch=phing.tasks.ext.StopwatchTask

--- a/classes/phing/tasks/ext/NotifySendTask.php
+++ b/classes/phing/tasks/ext/NotifySendTask.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Utilise notify-send from within Phing.
+ *
+ * PHP Version 5
+ *
+ * @category Tasks
+ * @package  phing.tasks.ext
+ * @author   Ken Guest <ken@linux.ie>
+ * @license  LGPL (see http://www.gnu.org/licenses/lgpl.html)
+ * @link     https://github.com/kenguest/Phing-NotifySendTask
+ */
+
+require_once 'phing/Task.php';
+
+/**
+ * NotifySendTask
+ *
+ * @category Tasks
+ * @package  phing.tasks.ext
+ * @author   Ken Guest <ken@linux.ie>
+ * @license  LGPL (see http://www.gnu.org/licenses/lgpl.html)
+ * @link     NotifySendTask.php
+ */
+class NotifySendTask extends Task
+{
+    protected $msg = null;
+    protected $title = null;
+    protected $icon = 'info';
+    protected $silent = false;
+
+    /**
+     * Set icon attribute
+     *
+     * @param string $icon name/location of icon
+     *
+     * @return void
+     */
+    public function setIcon($icon)
+    {
+        switch ($icon)
+        {
+        case 'info':
+        case 'error':
+        case 'warning':
+            $this->icon = $icon;
+            break;
+        default:
+            if (file_exists($icon) && is_file($icon)) {
+                $this->icon = $icon;
+            } else {
+                if (isset($this->log)) {
+                    $this->log(
+                        sprintf(
+                            "%s is not a file. Using default icon instead.",
+                            $icon
+                        ),
+                        Project::MSG_WARN
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Get icon to be used (filename or generic name)
+     *
+     * @return string
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * Set to a true value to not execute notifysend command.
+     *
+     * @param bool $silent Don't execute notifysend? True not to.
+     *
+     * @return void
+     */
+    public function setSilent($silent)
+    {
+        $this->silent = (bool) $silent;
+    }
+
+    /**
+     * Set title attribute
+     *
+     * @param string $title Title to display
+     *
+     * @return void
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Get Title
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set msg attribute
+     *
+     * @param string $msg Message
+     *
+     * @return void
+     */
+    public function setMsg($msg)
+    {
+        $this->msg = $msg;
+    }
+
+    /**
+     * Get message.
+     *
+     * @return string
+     */
+    public function getMsg()
+    {
+        return $this->msg;
+    }
+
+    /**
+     * The main entry point method.
+     *
+     * @throws BuildException
+     * @return void
+     */
+    public function main()
+    {
+        $msg = '';
+        $title = 'Phing';
+
+        if ($this->title != '') {
+            $title = "'" . $this->title . "'";
+        }
+
+        if ($this->msg != '') {
+            $msg = "'" . $this->msg . "'";
+        }
+
+        $cmd = 'notify-send -i ' . $this->icon . ' ' . $title . ' ' . $msg;
+
+        $this->log(sprintf("cmd: %s", $cmd), Project::MSG_DEBUG);
+        if (!$this->silent) {
+            exec(escapeshellcmd($cmd), $output, $return);
+            if ($return !== 0) {
+                throw new BuildException("Notify task failed.");
+            }
+        }
+        $this->log(sprintf("Title: '%s'", $title), Project::MSG_DEBUG);
+        $this->log(sprintf("Message: '%s'", $msg), Project::MSG_DEBUG);
+        $this->log($msg, Project::MSG_INFO);
+    }
+}
+
+// vim:set et ts=4 sw=4:

--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -5701,6 +5701,53 @@ Note that you can omit both startpoint and track attributes in this case
         </sect2>
     </sect1>
 
+    <sect1 role="taskdef" xml:id="NotifySendTask">
+        <title>NotifySendTask</title>
+        <para>This is a wrapper for notify-send, for displaying desktop notifications locally.</para>
+        <table>
+            <title>Attributes</title>
+            <tgroup cols="5">
+                <colspec colname="name" colnum="1" colwidth="1.5*"/>
+                <colspec colname="type" colnum="2" colwidth="0.8*"/>
+                <colspec colname="description" colnum="3" colwidth="3.5*"/>
+                <colspec colname="default" colnum="4" colwidth="0.8*"/>
+                <colspec colname="required" colnum="5" colwidth="1.2*"/>
+                <thead>
+                    <row>
+                        <entry>Name</entry>
+                        <entry>Type</entry>
+                        <entry>Description</entry>
+                        <entry>Default</entry>
+                        <entry>Required</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry><literal>icon</literal></entry>
+                        <entry><literal role="type">string</literal></entry>
+                        <entry>Specify an icon filename or stock icon to display.</entry>
+                        <entry>info</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry><literal>message</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Text to display. Use \n to specify a line break</entry>
+                        <entry>n/a</entry>
+                        <entry>Yes</entry>
+                    </row>
+                    <row>
+                        <entry><literal>title</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Title, or summary, of the notification.</entry>
+                        <entry>none</entry>
+                        <entry>No</entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+    </sect1>
+
     <sect1 role="taskdef" xml:id="ParallelTask">
         <title>ParallelTask</title>
         <para>Executes nested tasks in parallel.</para>

--- a/test/build.xml
+++ b/test/build.xml
@@ -70,6 +70,7 @@
 	    	</then>
 		</if>
 		<phpunit codecoverage="${tests.codecoverage}" haltonerror="true" haltonfailure="true" printsummary="true"
+            pharlocation="/usr/local/bin/phpunit"
 	    	configuration="phpunit-sparse.xml" bootstrap="../vendor/autoload.php">
 			<formatter type="xml" usefile="true" todir="${tests.reports.dir.resolved}" outfile="test-results.xml" />
             <formatter type="clover" todir="${tests.reports.dir.resolved}"/>

--- a/test/classes/phing/tasks/ext/NotifySendTaskTest.php
+++ b/test/classes/phing/tasks/ext/NotifySendTaskTest.php
@@ -1,0 +1,55 @@
+<?php
+require_once 'phing/BuildFileTest.php';
+class NotifySendTaskTest extends BuildFileTest
+{
+
+    protected $object;
+
+    public function setUp()
+    {
+        $this->configureProject(PHING_TEST_BASE . "/etc/tasks/ext/NotifySendTaskTest.xml");
+        $this->object = new NotifySendTask();
+
+    }
+
+    public function testEmptyMessage()
+    {
+        $this->executeTarget("testEmptyMessage");
+        $this->assertInLogs('cmd: notify-send -i info Phing');
+        $this->assertInLogs("Message: ''", Project::MSG_DEBUG);
+    }
+
+    public function testSettingTitle()
+    {
+        $this->object->setTitle("Test");
+        $this->assertEquals("Test", $this->object->getTitle());
+        $this->object->setTitle("Test Again");
+        $this->assertEquals("Test Again", $this->object->getTitle());
+
+    }
+    public function testSettingMsg()
+    {
+        $this->object->setMsg("Test");
+        $this->assertEquals("Test", $this->object->getMsg());
+        $this->object->setMsg("Test Again");
+        $this->assertEquals("Test Again", $this->object->getMsg());
+    }
+
+    public function testSetStandardIcon()
+    {
+        $this->object->setIcon("info");
+        $this->assertEquals("info", $this->object->getIcon());
+
+        $this->object->setIcon("error");
+        $this->assertEquals("error", $this->object->getIcon());
+
+        $this->object->setIcon("warning");
+        $this->assertEquals("warning", $this->object->getIcon());
+    }
+
+    public function testSetNonStandardIcon()
+    {
+        $this->object->setIcon("informational");
+        $this->assertEquals("info", $this->object->getIcon());
+    }
+}

--- a/test/etc/tasks/ext/NotifySendTaskTest.xml
+++ b/test/etc/tasks/ext/NotifySendTaskTest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="NotifySendTaskTest" default="testEmptyMessage">
+  <target name="testEmptyMessage">
+    <notifysend silent="1" />
+  </target>
+</project>


### PR DESCRIPTION
This will enable phing to send desktop notifications via notify-send.
The code for this was sitting in my separate repo ( https://github.com/kenguest/Phing-NotifySendTask ), but I've added extra logging, unit tests, and documentation.