### PR TITLE
Added CutDirsMapper

### DIFF
--- a/classes/phing/mappers/CutDirsMapper.php
+++ b/classes/phing/mappers/CutDirsMapper.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+include_once 'phing/BuildException.php';
+include_once 'phing/mappers/FileNameMapper.php';
+
+/**
+ * A mapper that strips of the a configurable number of leading
+ * directories from a file name.
+ *
+ * @author  Siad Ardroumli <siad.ardroumli@gmail.com>
+ * @package phing.mappers
+ */
+class CutDirsMapper implements FileNameMapper
+{
+    private $dirs = 0;
+
+    /**
+     * Empty implementation.
+     * @param mixed $ignore ignored.
+     */
+    public function setFrom($ignore)
+    {
+    }
+
+    /**
+     * The number of leading directories to cut.
+     * @param int $dirs
+     */
+    public function setTo($dirs)
+    {
+        $this->dirs = (int) $dirs;
+    }
+
+    /** {@inheritDoc}. */
+    public function main($sourceFileName)
+    {
+        if ($this->dirs <= 0) {
+            throw new BuildException('dirs must be set to a positive number');
+        }
+        $fileSep = PhingFile::$separator;
+        $fileSepCorrected = str_replace(array('/', '\\'), $fileSep, $sourceFileName);
+        $nthMatch = strpos($fileSepCorrected, $fileSep);
+
+        for ($n = 1; $nthMatch > -1 && $n < $this->dirs; $n++) {
+            $nthMatch = strpos($fileSepCorrected, $fileSep, $nthMatch + 1);
+        }
+
+        if ($nthMatch === false) {
+            return null;
+        }
+
+        return array(substr($sourceFileName, $nthMatch + 1));
+    }
+}

--- a/classes/phing/types/Mapper.php
+++ b/classes/phing/types/Mapper.php
@@ -245,6 +245,9 @@ class Mapper extends DataType
                 case 'composite':
                     $this->classname = 'phing.mappers.CompositeMapper';
                     break;
+                case 'cutdirs':
+                    $this->classname = 'phing.mappers.CutDirsMapper';
+                    break;
                 case 'identity':
                     $this->classname = 'phing.mappers.IdentityMapper';
                     break;

--- a/docs/docbook5/en/source/appendixes/coremappers.xml
+++ b/docs/docbook5/en/source/appendixes/coremappers.xml
@@ -203,6 +203,35 @@
             </table>
         </sect2>
     </sect1>
+    <sect1 xml:id="CutDirsMapper">
+    <title>CutDirsMapper </title>
+    <para>The <literal>CutDirsMapper</literal> strips a configured number of
+        leading directories from the source file name.</para>
+    <sect2>
+        <title>Examples</title>
+        <programlisting language="xml">&lt;mapper type=&quot;cutdirs&quot; to=&quot;1&quot;/&gt;</programlisting>
+        <para>The mapper as above will do the following mappings:</para>
+        <table>
+            <title>Result of mapping</title>
+            <tgroup cols="2">
+                <colspec colname="name" colnum="1" colwidth="1*"/>
+                <colspec colname="name" colnum="2" colwidth="1*"/>
+                <thead>
+                    <row>
+                        <entry>From</entry>
+                        <entry>To</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry><filename>foo/bar/A.txt</filename></entry>
+                        <entry>bar/A.txt</entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+    </sect2>
+    </sect1>
     <sect1 xml:id="FlattenMapper">
         <title>FlattenMapper </title>
         <para>The <literal>FlattenMapper</literal> removes the directories from a filename and

--- a/test/classes/phing/types/MapperTest.php
+++ b/test/classes/phing/types/MapperTest.php
@@ -186,4 +186,11 @@ class TaskdefForCopyTest extends BuildFileTest
         $this->assertNotInLogs('.php1');
         $this->assertInLogs('.php2');
     }
+    public function testCutDirsMapper()
+    {
+        $this->executeTarget("testCutDirsMapper");
+        $outputDir = $this->getProject()->getProperty('output');
+        $this->assertFileExists($outputDir . '/D');
+        $this->assertFileExists($outputDir . '/c/E');
+    }
 }

--- a/test/etc/types/mapper.xml
+++ b/test/etc/types/mapper.xml
@@ -53,6 +53,18 @@
     </copy>
   </target>
 
+  <target name="testCutDirsMapper">
+    <property name="input" value="copytest/testinput"/>
+    <property name="output" value="copytest/testoutput"/>
+    <mkdir dir="${input}/a/b/c"/>
+    <touch file="${input}/a/b/D"/>
+    <touch file="${input}/a/b/c/E"/>
+    <copy todir="${output}">
+      <mapper type="cutdirs" to="2"/>
+      <fileset dir="${input}"/>
+    </copy>
+  </target>
+
   <target name="cleanup">
     <delete dir="copytest" />
   </target>


### PR DESCRIPTION
Added ant like `CutDirsMapper`.

Example:
```
    <property name="input" value="${php.tmpdir}/testinput"/>
    <property name="output" value="${php.tmpdir}/testoutput"/>
    <mkdir dir="${input}/a/b/c"/>
    <touch file="${input}/a/b/D"/>
    <touch file="${input}/a/b/c/E"/>
    <copy todir="${output}">
        <mapper type="cutdirs" to="2"/>
        <fileset dir="${input}"/>
    </copy>
```
Would result in:
```
[copy] Copying 2 files to C:\Users\xxx\AppData\Local\Temp\testoutput
[copy] From C:\Users\xxx\AppData\Local\Temp\testinput\a\b\c\E to C:\Users\xxx\AppData\Local\Temp\testoutput\c\E
[copy] From C:\Users\xxx\AppData\Local\Temp\testinput\a\b\D to C:\Users\xxx\AppData\Local\Temp\testoutput\D
```
Documentation and tests are on the way ;)