### PR TITLE
Fixes #1208 - Inform the user why an archive could not be extracted.

### DIFF
--- a/classes/phing/tasks/ext/UntarTask.php
+++ b/classes/phing/tasks/ext/UntarTask.php
@@ -70,7 +70,7 @@ class UntarTask extends ExtractBaseTask
         try {
             $tar = $this->initTar($tarfile);
             if (!$tar->extractModify($this->todir->getAbsolutePath(), $this->removepath, $this->preservePermissions)) {
-                throw new BuildException('Failed to extract tar file: ' . $tarfile->getAbsolutePath());
+                throw new BuildException('Failed to extract tar file: ' . $tarfile->getAbsolutePath() . '. Error: ' . $tar->error_object->getMessage());
             }
         } catch (IOException $ioe) {
             $msg = "Could not extract tar file: " . $ioe->getMessage();


### PR DESCRIPTION
This is a fix for [Issue #1208: When UntarTask fails to extract an archive it should tell why](https://www.phing.info/trac/ticket/1208).