### PR TITLE
Task webserver

### DIFF
--- a/classes/phing/tasks/defaults.properties
+++ b/classes/phing/tasks/defaults.properties
@@ -154,6 +154,7 @@ parallel=phing.tasks.ext.ParallelTask
 symfonyconsole=phing.tasks.ext.SymfonyConsole.SymfonyConsoleTask
 composer=phing.tasks.ext.ComposerTask
 autoloader=phing.tasks.ext.AutoloaderTask
+webserver=phing.tasks.ext.ServerTask
 ; liquibase
 liquibase-changelog=phing.tasks.ext.liquibase.LiquibaseChangeLogTask
 liquibase-dbdoc=phing.tasks.ext.liquibase.LiquibaseDbDocTask

--- a/classes/phing/tasks/ext/ServerTask.php
+++ b/classes/phing/tasks/ext/ServerTask.php
@@ -142,11 +142,11 @@ class ServerTask extends Task
 
         $cmd = Commandline::toString($this->commandline->getCommandline(), true);
 
-        $streams = [
-            ["file", "/dev/null", "r"],
-            ["file", "/dev/null", "w"],
-            ["file", "/dev/null", "w"],
-        ];
+        $streams = array(
+            array("file", "/dev/null", "r"),
+            array("file", "/dev/null", "w"),
+            array("file", "/dev/null", "w"),
+        );
 
         $handle = proc_open($cmd, $streams, $pipes);
 

--- a/classes/phing/tasks/ext/ServerTask.php
+++ b/classes/phing/tasks/ext/ServerTask.php
@@ -136,6 +136,8 @@ class ServerTask extends Task
      */
     public function main()
     {
+        $exception = null;
+
         $this->prepare();
 
         $cmd = Commandline::toString($this->commandline->getCommandline(), true);
@@ -173,11 +175,17 @@ class ServerTask extends Task
             foreach ($this->tasks as $task) {
                 $task->perform();
             }
-        } finally {
-            // Terminate server with SIGINT
-            proc_terminate($handle, 2);
+        } catch(Exception $e) {
+            $exception = $e;
+        }
 
-            $this->log("Stopped web server", Project::MSG_INFO);
+        // Terminate server with SIGINT
+        proc_terminate($handle, 2);
+
+        $this->log("Stopped web server", Project::MSG_INFO);
+
+        if (!is_null($exception)) {
+            throw $exception;
         }
     }
 

--- a/classes/phing/tasks/ext/ServerTask.php
+++ b/classes/phing/tasks/ext/ServerTask.php
@@ -176,7 +176,8 @@ class ServerTask extends Task
             } else {
                 // Wait 0.5 seconds to allow the webserver to shutdown.
                 usleep(500000);
-                if(!proc_get_status($handle)['running'])
+                $server_status = proc_get_status($handle);
+                if(!$server_status['running'])
                 {
                     rewind($temp_err);
                     $err_message = stream_get_contents($temp_err);

--- a/classes/phing/tasks/ext/ServerTask.php
+++ b/classes/phing/tasks/ext/ServerTask.php
@@ -152,7 +152,10 @@ class ServerTask extends Task
 
         if (!is_resource($handle)) {
             throw new BuildException(
-                get_class($this) . ' could not start web server.'
+                sprintf(
+                    "%s failed to start server process.",
+                    get_class($this)
+                )
             );
         } else {
             $this->log(

--- a/classes/phing/tasks/ext/ServerTask.php
+++ b/classes/phing/tasks/ext/ServerTask.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+require_once 'phing/tasks/system/SequentialTask.php';
+
+/**
+ * Run the build-in php web server.
+ *
+ * @author    Marcel Metz <mmetz@adrian-broher.net>
+ * @version   $Id$
+ * @package   phing.tasks.ext
+ */
+class ServerTask extends SequentialTask
+{
+
+    /** The document root directory used by the server.
+     *
+     * Defaults to the phing project.basedir property.
+     */
+    protected $docroot = null;
+
+    /** The ip address the server should listen on.
+     *
+     * Defaults to 127.0.0.1.
+     */
+    protected $address = "127.0.0.1";
+
+    /** The port the server should listen on.
+     *
+     * Defaults to 8080.
+     */
+    protected $port = 8080;
+
+    /** The path to the router script, which should displatch requests. */
+    protected $router = null;
+
+    /**
+     * Load the necessary environment for running this task.
+     *
+     * @throws BuildException
+     */
+    public function init()
+    {
+        if (version_compare(PHP_VERSION, '5.5.0') <= 0) {
+            throw new BuildException(
+                get_class($this) . ' requires at least PHP version 5.5.'
+            );
+        }
+    }
+
+    /**
+     * Starts the web server and runs the encapsulated tasks.
+     */
+    public function main()
+    {
+        if (!isset($this->docroot)) {
+            $this->docroot = $this->project->getProperty("project.basedir");
+        }
+
+        $router = isset($this->router) ? escapeshellarg($this->router) : '';
+
+        $cmd = sprintf(
+            "%s -S %s:%d -t %s %s",
+            escapeshellarg(PHP_BINARY),
+            $this->address,
+            $this->port,
+            escapeshellarg($this->docroot),
+            $router
+        );
+
+        $this->log("\$cmd: " . $cmd, Project::MSG_DEBUG);
+
+        $streams = [
+            ["file", "/dev/null", "r"],
+            ["file", "/dev/null", "w"],
+            ["file", "/dev/null", "w"],
+        ];
+
+        $handle = proc_open($cmd, $streams, $pipes);
+
+        if (!is_resource($handle)) {
+            throw new BuildException(
+                get_class($this) . ' could not start web server.'
+            );
+        } else {
+            $this->log(
+                sprintf(
+                    "Started web server, listening on http://%s:%d",
+                    $this->address,
+                    $this->port
+                ),
+                Project::MSG_INFO
+            );
+
+            $msg = isset($this->router)
+                ? sprintf("with %s as docroot and %s as router", $this->docroot, $this->router)
+                : sprintf("with %s as docroot", $this->docroot);
+
+            $this->log($msg, Project::MSG_VERBOSE);
+        }
+
+        try {
+            foreach ($this->nestedTasks as $task) {
+                $task->perform();
+            }
+        } finally {
+            // Terminate server with SIGINT
+            proc_terminate($handle, 2);
+
+            $this->log("Stopped web server", Project::MSG_INFO);
+        }
+    }
+
+    /**
+     * @param string $address The ip address the server should listen on.
+     */
+    public function setAddress($address)
+    {
+        $this->address = $address;
+    }
+
+    /**
+     * @param string $docroot The directory which should be used as document
+     *        root.
+     */
+    public function setDocRoot($docroot)
+    {
+        $this->docroot = $docroot;
+    }
+
+    /**
+     * @param string $port The port the server should listen on.
+     */
+    public function setPort($port)
+    {
+        $this->port = $port;
+    }
+
+    /**
+     * @param string $router The router script, that should dispatch
+     *        requests.
+     */
+    public function setRouter($router)
+    {
+        $this->router = $router;
+    }
+}

--- a/classes/phing/tasks/ext/ServerTask.php
+++ b/classes/phing/tasks/ext/ServerTask.php
@@ -162,6 +162,21 @@ class ServerTask extends Task
                     )
                 );
             } else {
+                // Wait 0.5 seconds to allow the webserver to shutdown.
+                usleep(500000);
+                if(!proc_get_status($handle)['running'])
+                {
+                    rewind($temp_err);
+                    $err_message = stream_get_contents($temp_err);
+
+                    throw new BuildException(
+                        sprintf(
+                            "Web server stopped prematurely. Server reported: %s",
+                            $err_message
+                        )
+                    );
+                }
+
                 $this->log(
                     sprintf(
                         "Started web server, listening on http://%s:%d",

--- a/classes/phing/tasks/ext/ServerTask.php
+++ b/classes/phing/tasks/ext/ServerTask.php
@@ -20,9 +20,21 @@
  * <http://phing.info>.
  */
 
+require_once 'phing/BuildListener.php';
 require_once 'phing/TaskContainer.php';
 require_once 'phing/Task.php';
 require_once 'phing/types/Commandline.php';
+
+/* E_DEPRECATED was introduced in PHP 5.3, but PHING is PHP 5.2 backward
+ * compatible. */
+if(!defined('E_DEPRECATED')) {
+    define('E_DEPRECATED', 0x2000);
+}
+
+/* E_TRACE is a custom constant to represent tracing messages. */
+if(!defined('E_TRACE')) {
+    define('E_TRACE', 0x0);
+}
 
 /**
  * Run the build-in php web server.
@@ -193,6 +205,9 @@ class ServerTask extends Task
                 $this->log($msg, Project::MSG_VERBOSE);
             }
 
+            $message_multiplexer = new ServerMessageMultiplexer($this, $temp_out, $temp_err);
+
+            $this->project->addBuildListener($message_multiplexer);
 
             try {
                 foreach ($this->tasks as $task) {
@@ -201,6 +216,8 @@ class ServerTask extends Task
             } catch(Exception $e) {
                 $exception = $e;
             }
+
+            $this->project->removeBuildListener($message_multiplexer);
         } catch(Exception $e) {
             $exception = $e;
         }
@@ -314,5 +331,427 @@ class ServerTaskForwarder implements TaskContainer
     public function addTask(Task $task)
     {
         $this->outer->addTask($task);
+    }
+}
+
+/** A class to multiplex webserver messages into phing log messages
+ *
+ * @author Marcel Metz <mmetz@adrian-broher.net>
+ * @package phing.tasks.ext
+ */
+class ServerMessageMultiplexer implements BuildListener
+{
+    /** PCRE pattern to separate PHP CLI server log entries
+     *
+     * The PHP CLI server uses the asctime_r (POSIX) or ctime_s (WIN32)
+     * format to prefix every log entry.  This can be used to split up
+     * the log data into log entries, even in the case log entries span
+     * over sereral lines.
+     */
+    const PHP_CLI_SERVER_TIMESTAMP_PATTERN =
+        '#\\[[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-3][0-9] [ 0-2][0-9]:[ 0-5][0-9]:[ 0-5][0-9] [0-9]{4}\\] #';
+
+    /** PCRE pattern to identify and process a HTTP response log entry
+     *
+     * The PHP CLI server emits a log entry for every processed HTTP
+     * request containing the client IP and port, the HTTP status code,
+     * the requested URL and optional informations to the request.
+     *
+     * The pattern contains the following named capture groups to access
+     * the mentioned data entries:
+     *
+     * client_ip:   IPv4 or IPv6 address of the client that initiated
+     *              the request.
+     * client_port: The TCP port of the client that initiated the request.
+     * status:      The HTTP status code sent by the server.
+     * url:         The requested URL.
+     * info:        Optional additional information;  contents depends
+     *              on the request issued.
+     */
+    const PHP_CLI_SERVER_RESPONSE_PATTERN =
+        '#^(?P<client_ip>[][\\.:[:digit:]]+):(?P<client_port>[[:digit:]]{1,5}) \\[(?P<status>[[:digit:]]{3})\\]: (?P<url>[[:^space:]]*)(?: - (?P<info>.+))?$#';
+
+    /** PCRE pattern to identify and process a server log entry
+     *
+     * The PHP CLI server emits PHP errors or infos on the standard
+     * error file stream (STDERR).  These entries contain a severity and
+     * an additinal message.
+     *
+     * The pattern contains the following named capture groups to access
+     * the mentioned data entries:
+     *
+     * level:   A string representing the PHP error level.
+     * message: The message logged by the server.
+     */
+    const PHP_CLI_SERVER_ENTRY_PATTERN =
+        '#^PHP (?P<level>Fatal error|Catchable fatal error|Warning|Parse error|Notice|Strict Standards|Deprecated):  (?P<message>.+)$#';
+
+    public function __construct($outer, $out, $err)
+    {
+        $this->outer = $outer;
+        $this->out = $out;
+        $this->err = $err;
+        $this->injecting = false;
+    }
+
+    /** @see BuildListener::buildStarted() */
+    public function buildStarted(BuildEvent $event)
+    {}
+
+    /** @see BuildListener::buildFinished() */
+    public function buildFinished(BuildEvent $event)
+    {}
+
+    /** @see BuildListener::targetStarted() */
+    public function targetStarted(BuildEvent $event)
+    {}
+
+    /** @see BuildListener::targetFinished() */
+    public function targetFinished(BuildEvent $event)
+    {}
+
+    /** @see BuildListener::taskStarted() */
+    public function taskStarted(BuildEvent $event)
+    {}
+
+    /** @see BuildListener::taskFinished() */
+    public function taskFinished(BuildEvent $event)
+    {}
+
+    /** Intercept messages created and inject web server log entries
+     *
+     * @see BuildListener::messageLogged()
+     */
+    public function messageLogged(BuildEvent $event)
+    {
+        if(!$this->injecting)
+        {
+            $this->injecting = true;
+
+            $out_entries = $this->convertToLogEntries($this->out);
+            $err_entries = $this->convertToLogEntries($this->err);
+
+            foreach($out_entries as $entry) {
+                $message = sprintf(
+                    "Response %1d %2s -> %3s:%4s (%5s): %6s",
+                    $entry['status'],
+                    $entry['url'],
+                    $entry['client_ip'],
+                    $entry['client_port'],
+                    $this->ErrorLevelToString($entry['level']),
+                    $entry['message']
+                );
+                $this->outer->log($message, Project::MSG_INFO);
+            }
+            foreach($err_entries as $entry) {
+                $message = sprintf(
+                    "Response %1d %2s -> %3s:%4s (%5s): %6s",
+                    $entry['status'],
+                    $entry['url'],
+                    $entry['client_ip'],
+                    $entry['client_port'],
+                    $this->ErrorLevelToString($entry['level']),
+                    $entry['message']
+                );
+                $this->outer->log($message, Project::MSG_INFO);
+            }
+
+            $this->injecting = false;
+        }
+    }
+
+    /** Extract log entries from file stream
+     *
+     * @param Resource $logHandle An open file handle containing the output
+     *        of the PHP CLI web server
+     *
+     * @return An array containing log entries. The array contains the keys:
+     *         client_ip:   IPv4 or IPv6 address of the client that
+     *                      initiated the request.
+     *         client_port: The TCP port of the client that initiated the
+     *                      request.
+     *         status:      The HTTP status code sent by the server.
+     *         url:         The requested URL.
+     *         level:       A PHP error constant or E_TRACE.
+     *         message:     The message logged by the server.
+     *
+     * @throws UnexpectedValueException if the log data contains a line
+     *         of a unknown format.
+     * @throws UnexpectedValueException if the log data contains messages
+     *         that can't be associated to a HTTP request.
+     */
+    private function convertToLogEntries($logHandle)
+    {
+        $result= array();
+
+        rewind($logHandle);
+        $logText = stream_get_contents($logHandle);
+        rewind($logHandle);
+        ftruncate($logHandle, 0);
+
+        $logEntries = preg_split(self::PHP_CLI_SERVER_TIMESTAMP_PATTERN, $logText, -1, PREG_SPLIT_NO_EMPTY);
+
+        $messages =  array();
+
+        foreach($logEntries as $logEntry) {
+            $response = array();
+            $serverEntry = array();
+
+            if(preg_match(self::PHP_CLI_SERVER_RESPONSE_PATTERN, $logEntry, $response)) {
+                foreach($response as $key => $match) {
+                    if(is_int($key)) {
+                        unset($response[$key]);
+                    }
+                }
+
+                $messages[] = array(
+                    'level' => E_TRACE,
+                    'message' => ''
+                );
+
+                foreach($messages as $message) {
+                    if(empty($message['message']) && array_key_exists('info', $response)) {
+                        $message['message'] = $response['info'];
+                    } else if(empty($message['message'])) {
+                        $message['message'] = $this->HTTPStatusToMessage($response['status']);
+                    }
+
+                    $result[] = array_merge($response, $message);
+
+                }
+
+                $messages = array();
+            } else if(preg_match(self::PHP_CLI_SERVER_ENTRY_PATTERN, $logEntry, $serverEntry)) {
+                $messages[] = array(
+                    'level' => $this->LogErrorStringToErrorLevel($serverEntry['level']),
+                    'message' => $serverEntry['message']
+                );
+            } else {
+                $this->outer->log(
+                    sprintf(
+                        "Unexpected line in log output: %s",
+                        $logEntry
+                    ),
+                    Project::MSG_ERROR
+                );
+            }
+        }
+
+        foreach($message as $message) {
+            $this->outer->log(
+                sprintf(
+                    "Log entry without associated server response: (%s) %s",
+                    $this->ErrorLevelToString($message['level']),
+                    $message['message']
+                ),
+                Project::MSG_ERROR
+            );
+        }
+
+        return $result;
+    }
+
+    /** Convert PHP CLI error level string to PHP error level constant
+     *
+     * @param $errorString The error string that should be converted
+     *        to a error level constant.
+     *
+     * @return The error level constant associtated with the given
+     *         error string.
+     *
+     * @throws UnexpectedValueException if the error string has no known
+     *         conversion.
+     */
+    private function LogErrorStringToErrorLevel($errorString)
+    {
+        switch($errorString) {
+            case "Fatal error":
+                return E_ERROR;
+            case "Catchable fatal error":
+                return E_RECOVERABLE_ERROR;
+            case "Warning":
+                return E_WARNING;
+            case "Parse error":
+                return E_PARSE;
+            case "Notice":
+                return E_NOTICE;
+            case "Strict Standards":
+                return E_STRICT;
+            case "Deprecated":
+                return E_DEPRECATED;
+            default:
+                throw new UnexpectedValueException(
+                    sprintf(
+                        "Unhandled error string: \"%s\"",
+                        $errorString
+                    )
+                );
+        }
+    }
+
+    /** Convert PHP error level constant to human readable text
+     *
+     * @param $level The error level constant that should be converted
+     *        to a human readable string.
+     *
+     * @return The human readable string associtated with the given
+     *         error level constant.
+     *
+     * @throws UnexpectedValueException if the error level has no known
+     *         conversion.
+     */
+    private function ErrorLevelToString($level)
+    {
+        switch($level) {
+            case E_ERROR:
+                return "Error";
+            case E_RECOVERABLE_ERROR:
+                return "Recoverable Error";
+            case E_WARNING:
+                return "Warning";
+            case E_PARSE:
+                return "Parse error";
+            case E_NOTICE:
+                return "Notice";
+            case E_STRICT:
+                return "Strict Standards";
+            case E_DEPRECATED:
+                return "Deprecated";
+            case E_TRACE:
+                return "Trace";
+            default:
+                throw new UnexpectedValueException(
+                    sprintf(
+                        "Unhandled error level: %d",
+                        $level
+                    )
+                );
+        }
+    }
+
+    /** Convert HTTP status code to human readable text
+     *
+     * @param $level The HTTP status code that should be converted
+     *        to a human readable string.
+     *
+     * @return The human readable string associtated with the given
+     *         HTTP status code.
+     *
+     * @throws UnexpectedValueException if the HTTP status code has no
+     *         known conversion.
+     */
+    private function HTTPStatusToMessage($status)
+    {
+        switch($status) {
+            case 100:
+                return "Continue";
+            case 101:
+                return "Switching Protocols";
+            case 200:
+                return "Success";
+            case 201:
+                return "Created";
+            case 202:
+                return "Accepted";
+            case 203:
+                return "Non-Authorative Information";
+            case 204:
+                return "No Content";
+            case 205:
+                return "Reset Content";
+            case 206:
+                return "Partial Content";
+            case 300:
+                return "Multiple Choices";
+            case 301:
+                return "Moved Permanenty";
+            case 302:
+                return "Found";
+            case 303:
+                return "See Other";
+            case 304:
+                return "Not Modified";
+            case 305:
+                return "Use Proxy";
+            case 306:
+                return "Switch Proxy";
+            case 307:
+                return "Temporary Redirect";
+            case 308:
+                return "Permanent Redirect";
+            case 400:
+                return "Bad Request";
+            case 401:
+                return "Unauthorized";
+            case 402:
+                return "Payment Required";
+            case 403:
+                return "Forbidden";
+            case 404:
+                return "Not Found";
+            case 405:
+                return "Method Not Allowed";
+            case 406:
+                return "Not Acceptable";
+            case 407:
+                return "Proxy Authentication Required";
+            case 408:
+                return "Request Timeout";
+            case 409:
+                return "Conflict";
+            case 410:
+                return "Gone";
+            case 411:
+                return "Length Required";
+            case 412:
+                return "Precondition Failed";
+            case 413:
+                return "Payload Too Large";
+            case 414:
+                return "URI Too Long";
+            case 415:
+                return "Unsupported Media Type";
+            case 416:
+                return "Range Not Satisfiable";
+            case 417:
+                return "Expectation Failed";
+            case 421:
+                return "Misdirected Request";
+            case 426:
+                return "Upgrade Required";
+            case 428:
+                return "Precondition Required";
+            case 429:
+                return "Too Many Requests";
+            case 431:
+                return "Request Header Fields Too Large";
+            case 451:
+                return "Unavailable For Legal Reasons";
+            case 500:
+                return "Internal Server Error";
+            case 501:
+                return "Not Implemented";
+            case 502:
+                return "Bad Gateway";
+            case 503:
+                return "Service Unavailable";
+            case 504:
+                return "Gateway Timeout";
+            case 505:
+                return "HTTP Version Not Supported";
+            case 506:
+                return "Variant Also Negotiates";
+            case 510:
+                return "Not Extended";
+            case 511:
+                return "Network Authentication Required";
+            default:
+                throw new UnexpectedValueException(
+                    sprintf(
+                        "Unhandled HTTP status code: %d",
+                        $status
+                    )
+                );
+        }
     }
 }


### PR DESCRIPTION
Hello Phing devs,

this pull request contains a new task, which exposes the PHP built-in HTTP server. The purpose of this could be to run feature tests or other tasks that require a running HTTP server without the need to set up a full fledged HTTP server like Apache.

I'm using this task in another project for serveral month now and so far the implementation did work well and I hope that it can be useful for the phing upstream. However, the implementation had only limited testing on a single linux platform and was written by me for me so there is no proper documentation available yet.

I would like to ask for guidance and review on this task to make it acceptable for inclusion into Phing.
# Features

The `webserver` task allows developers to run an instance of built-in PHP (>= 5.5) webserver and executing abitary tasks while web server instance is running. IP-address, port, document root and a routing script can be optionally set by attributes. Also it is possible to set ini configurations with child `config` nodes. The tasks that should be executed with a running web server instance available are placed inside the `tasks` node.
# Requirements
- The tasks needs to be run with PHP 5.5 or later (maybe works even with PHP 5.4).
# Usage

``` xml
<webserver address="127.0.0.1" port="8080" docroot="${project.basedir}/src" router="${project.basedir}/src/router.php">
    <config name="auto_prepend_file" value="${project.basedir}/some-prepend-file.php" />
    <tasks>
        <sometask />
        <someothertask />
    </tasks>
</webserver>
```
# Missing parts
- The current task implementation was only tested on Linux with a recent PHP version. It may or may not work on other platforms and may or may not work with PHP 5.4 (the version that introduced the built-in web server).
- There are no unit tests available yet.
- There is no end user documentation available yet.
- All notices, messages and errors from the spawned web server are thrown away silently. I wanted to implement a filter for those and inject the output properly into the output of the parallel running tasks. So far I haven't found a way to hook into the Phing logging to intercept both the web server output and the embedded tasks to create sequencial and correct output.
- Maybe there is more code reuse from internal Phing classes possible.
# TODO
- [x] Make the code PHP 5.2 compatible
- [ ] Write unit tests
- [ ] Write user documentation
- [x] Implement a multiplexer for combining the phing tasks and php server output
- [ ] Implement a configurable filter for filtering out superfluous php server output
