### PR TITLE
Document new SSL attribute for FtpDeploy (#PR352).

### DIFF
--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -1202,6 +1202,13 @@
                         <entry>Yes</entry>
                     </row>
                     <row>
+                        <entry><literal>ssl</literal></entry>
+                        <entry><literal role="type">boolean</literal></entry>
+                        <entry>Whether to connect via SSL. This requires Net/FTP to be installed.</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
                         <entry><literal>dir</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Directory on the remote server.</entry>
@@ -1300,6 +1307,7 @@
   username="${ftp.username}"
   password="${ftp.password}"
   dir="${ftp.dir}"
+  ssl="true"
   passive="false"
   mode="${ftp.mode}">
   &lt;fileset dir=".">

--- a/docs/docbook5/en/source/chapters/settingup.xml
+++ b/docs/docbook5/en/source/chapters/settingup.xml
@@ -136,6 +136,13 @@
                             </entry>
                         </row>
                         <row>
+                            <entry>Net_FTP (PEAR package)</entry>
+                            <entry>Optional; enables SSL connection in FtpDeployTask</entry>
+                            <entry><link xlink:href="http://pear.php.net/package/Net_FTP"
+                                    role="external">http://pear.php.net/package/Net_FTP</link>
+                            </entry>
+                        </row>
+                        <row>
                             <entry>PHP Depend</entry>
                             <entry>Optional; enables additional task(s)</entry>
                             <entry><link xlink:href="http://www.pdepend.org" role="external"


### PR DESCRIPTION
This is the required documentation for the new SSL attribute added to the FtpDeployTask in https://github.com/phingofficial/phing/pull/352/ which was implemented by @patrickdreyer 

I've added a row describing the new SSL attribute to the section for FtpDeploy and also added Net_FTP as an optional dependency in the "Setting Up Phing" chapter.