### PR TITLE
Fixing bug in Yaml file parser.

### DIFF
--- a/classes/phing/system/io/YamlFileParser.php
+++ b/classes/phing/system/io/YamlFileParser.php
@@ -40,8 +40,9 @@ class YamlFileParser implements FileParserInterface
         try {
             // We load the Yaml class without the use of namespaces to prevent
             // parse errors in PHP 5.2.
-            $parser = '\Symfony\Component\Yaml\Parser';
-            $properties = $parser->parse($file->getAbsolutePath());
+            $parserClass = '\Symfony\Component\Yaml\Parser';
+            $parser = new $parserClass;
+            $properties = $parser->parse(file_get_contents($file->getAbsolutePath()));
         } catch (Exception $e) {
             if (is_a($e, '\Symfony\Component\Yaml\Exception\ParseException')) {
                 throw new IOException("Unable to parse contents of " . $file . ": " . $e->getMessage());

--- a/test/classes/phing/system/io/YamlFileParserTest.php
+++ b/test/classes/phing/system/io/YamlFileParserTest.php
@@ -49,8 +49,8 @@ class YamlFileParserTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (phpversion() < 5.3 || !class_exists('Yaml')) {
-            $this->markTestSkipped('Yaml is not installed.');
+        if (phpversion() < 5.3 || !class_exists('\Symfony\Component\Yaml\Parser')) {
+            $this->markTestIncomplete('Yaml is not installed.');
             exit;
         }
         $this->yamlFileStub = PHING_TEST_BASE .  "/etc/system/io/config.yml";


### PR DESCRIPTION
Looks like the most recent modification to the Yaml feature introduced a bug. This should fix it. Also need to see why regression test did not catch this.