### PR TITLE
Add propertyName to PhpCodeSniffer

### DIFF
--- a/classes/phing/tasks/ext/PhpCodeSnifferTask.php
+++ b/classes/phing/tasks/ext/PhpCodeSnifferTask.php
@@ -71,6 +71,7 @@ class PhpCodeSnifferTask extends Task
     private $haltonerror = false;
     private $haltonwarning = false;
     private $skipversioncheck = false;
+    private $propertyName = null;
 
     /**
      * Load the necessary environment for running PHP_CodeSniffer.
@@ -344,6 +345,23 @@ class PhpCodeSnifferTask extends Task
     }
 
     /**
+     * Sets the name of the property to use
+     * @param $propertyName
+     */
+    public function setPropertyName($propertyName)
+    {
+        $this->propertyName = $propertyName;
+    }
+
+    /**
+     * Returns the name of the property to use
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
+    }
+
+    /**
      * Executes PHP code sniffer against PhingFile or a FileSet
      */
     public function main()
@@ -518,16 +536,18 @@ class PhpCodeSnifferTask extends Task
      */
     protected function printErrorReport($phpcs)
     {
-        if ($this->showSniffs) {
-            $sniffs = $phpcs->getSniffs();
-            $sniffStr = '';
-            foreach ($sniffs as $sniff) {
-                if (is_string($sniff)) {
-                    $sniffStr .= '- ' . $sniff . PHP_EOL;
-                } else {
-                    $sniffStr .= '- ' . get_class($sniff) . PHP_EOL;
-                }
+        $sniffs = $phpcs->getSniffs();
+        $sniffStr = '';
+        foreach ($sniffs as $sniff) {
+            if (is_string($sniff)) {
+                $sniffStr .= '- ' . $sniff . PHP_EOL;
+            } else {
+                $sniffStr .= '- ' . get_class($sniff) . PHP_EOL;
             }
+        }
+        $this->project->setProperty($this->getPropertyName(), (string) $sniffStr);
+
+        if ($this->showSniffs) {
             $this->log('The list of used sniffs (#' . count($sniffs) . '): ' . PHP_EOL . $sniffStr, Project::MSG_INFO);
         }
 

--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -7209,6 +7209,14 @@ Note that you can omit both startpoint and track attributes in this case
                         <entry>No</entry>
                     </row>
                     <row>
+                        <entry><literal>propertyName</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>The name of the property to set. This will be populated
+                        with the names of the sniff that were used.</entry>
+                        <entry>n/a</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
                         <entry><literal>docGenerator</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>The name of the doc generator (HTML, Text).</entry>

--- a/test/classes/phing/tasks/ext/PhpCodeSnifferTaskTest.php
+++ b/test/classes/phing/tasks/ext/PhpCodeSnifferTaskTest.php
@@ -67,4 +67,15 @@ class PhpCodeSnifferTaskTest extends BuildFileTest
         );
         unlink(PHING_TEST_BASE . '/etc/tasks/ext/phpcs/report.txt');
     }
+
+    public function testPropertyOutput()
+    {
+        ob_start();
+        $this->executeTarget(__FUNCTION__);
+        $output = ob_get_clean();        
+        $this->assertPropertyEquals(
+            "PhpCodeSnifferTaskTest.testPropertyOutput",
+            "- Generic_Sniffs_PHP_DisallowShortOpenTagSniff" . PHP_EOL
+        );
+    }
 }

--- a/test/etc/tasks/ext/phpcs/build.xml
+++ b/test/etc/tasks/ext/phpcs/build.xml
@@ -21,4 +21,16 @@
             <formatter type="full" usefile="true" outfile="report.txt" />
         </phpcodesniffer>
     </target>
+
+    <target name="testPropertyOutput">
+        <phpcodesniffer
+            standard="PhingTest"
+            file="test.php"
+            showSniffs="false"
+            allowedFileExtensions="php"
+			propertyName="PhpCodeSnifferTaskTest.testPropertyOutput">
+            <config name="installed_paths" value="standards"/>
+            <formatter type="summary" usefile="false"  />
+        </phpcodesniffer>
+    </target>
 </project>


### PR DESCRIPTION
We had a case in the past where a sniff failed to run in our setup.  By having the sniffs in a property we would be able to validate that the sniffs were in fact used.