### PR TITLE
Added more function to MailLogger.

### DIFF
--- a/docs/docbook5/en/source/appendixes/coreloggers.xml
+++ b/docs/docbook5/en/source/appendixes/coreloggers.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model xlink:href="http://www.oasis-open.org/docbook/xml/5.0/rng/docbookxi.rng"
+        schematypens="http://relaxng.org/ns/structure/1.0"?>
+<appendix xmlns="http://docbook.org/ns/docbook"
+          version="5.0" xml:id="app.coreloggers">
+    <title>Loggers and Listeners</title>
+
+
+    <para>Phing has two related features to allow the build process to be
+        monitored:
+        listeners and loggers.
+    </para>
+
+    <sect1 role="loggerdef" xml:id="DefaultLogger">
+        <title>DefaultLogger</title>
+        <para>Simply run Phing normally, or:
+            <literal>phing -logger "phing.listener.DefaultLogger"</literal>
+        </para>
+    </sect1>
+
+    <sect1 role="loggerdef" xml:id="MailLogger">
+        <title>MailLogger</title>
+        <para>The MailLogger captures all output logged through DefaultLogger
+            (standard Phing output) and will send success and failure messages
+            to unique e-mail lists, with control for turning off success or
+            failure messages individually.
+        </para>
+
+        <table>
+            <title>Properties controlling the operation of MailLogger:
+            </title>
+            <tgroup cols="3">
+                <colspec colname="name" colnum="1" colwidth="1*"/>
+                <colspec colname="description" colnum="2" colwidth="1.5*"/>
+                <colspec colname="required" colnum="3" colwidth="1.5*"/>
+                <thead>
+                    <row>
+                        <entry>Property</entry>
+                        <entry>Description</entry>
+                        <entry>Required</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.from</literal>
+                        </entry>
+                        <entry>Mail "from" address</entry>
+                        <entry>Yes, if mail needs to be sent</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.replyto</literal>
+                        </entry>
+                        <entry>Mail "replyto" address(es), comma-separated</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.properties.file</literal>
+                        </entry>
+                        <entry>Filename of properties file that will override other values.</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.success.cc</literal>
+                        </entry>
+                        <entry>Address to send success messages to carbon copy (cc)</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.failure.cc</literal>
+                        </entry>
+                        <entry>Address to send failure messages to carbon copy (cc)</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.success.bcc</literal>
+                        </entry>
+                        <entry>Address to send success messages to blind carbon copy (bcc)</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.failure.bcc</literal>
+                        </entry>
+                        <entry>Address to send failure messages to blind carbon copy (bcc)</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.success.body</literal>
+                        </entry>
+                        <entry>fixed text of mail body for a successful build, default is to send the logfile</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.failure.body</literal>
+                        </entry>
+                        <entry>fixed text of mail body for a failed build, default is to send the logfile</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.success.subject</literal>
+                        </entry>
+                        <entry>Subject of successful build</entry>
+                        <entry>No - default to <literal>Build Success</literal></entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.failure.subject</literal>
+                        </entry>
+                        <entry>Subject of failed build</entry>
+                        <entry>No - default to <literal>Build Failure</literal></entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.success.to</literal>
+                        </entry>
+                        <entry>Address to send success messages to</entry>
+                        <entry>required if success mail to be sent</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.failure.to</literal>
+                        </entry>
+                        <entry>Address to send failure messages to</entry>
+                        <entry>required if failure mail to be sent</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.success.notify</literal>
+                        </entry>
+                        <entry>Send build success e-mails?</entry>
+                        <entry>No - default to true</entry>
+                    </row>
+                    <row>
+                        <entry>
+                            <literal>phing.log.mail.failure.notify</literal>
+                        </entry>
+                        <entry>Send build failure e-mails?</entry>
+                        <entry>No - default to true</entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+        <para>
+            <literal>phing -logger "phing.listener.MailLogger"</literal>
+        </para>
+    </sect1>
+
+    <sect1 role="loggerdef" xml:id="NoBannerLogger">
+        <title>NoBannerLogger</title>
+        <para>Removes output of empty target output.
+            <literal>phing -logger "phing.listener.NoBannerLogger"</literal>
+        </para>
+    </sect1>
+
+    <sect1 role="loggerdef" xml:id="TimestampedLogger">
+        <title>TimestampedLogger</title>
+        <para>Acts like the default logger, except that the final
+            success/failure message also includes the time that the build
+            completed.
+        </para>
+    </sect1>
+
+</appendix>


### PR DESCRIPTION
Added more properties to MailLogger:

- phing.mail.log.failure.notify [default: true] - Send build failure e-mails?
- phing.mail.log.success.notify [default: true] - Send build success e-mails?
- phing.mail.log.failure.to [required if failure mail to be sent] - Address to send failure messages to
- phing.mail.log.success.to [required if success mail to be sent] - Address to send success messages to
- phing.mail.log.failure.cc [no default] - Address to send failure messages to carbon copy (cc)
- phing.mail.log.success.to [no default] - Address to send success messages to carbon copy (cc)
- phing.mail.log.failure.bcc [no default] - Address to send failure messages to blind carbon copy (bcc)
- phing.mail.log.success.bcc [no default] - Address to send success messages to blind carbon copy (bcc)
- phing.mail.log.failure.subject [default: "Build Failure"] - Subject of failed build
- phing.mail.log.success.subject [default: "Build Success"] - Subject of successful build
- phing.mail.log.failure.body [default: none] - fixed text of mail body for a failed build, default is to send the logfile
- phing.mail.log.success.body [default: none] - fixed text of mail body for a successful build, default is to send the logfile
- phing.mail.log.properties.file [no default] - Filename of properties file that will override other values.