### PR TITLE
Fix doc block, type hint will not be used

### DIFF
--- a/classes/phing/tasks/ext/phpdoc/PhingPhpDocumentorErrorTracker.php
+++ b/classes/phing/tasks/ext/phpdoc/PhingPhpDocumentorErrorTracker.php
@@ -39,7 +39,7 @@ require_once 'PhpDocumentor/phpDocumentor/Errors.inc';
 class PhingPhpDocumentorErrorTracker extends ErrorTracker
 {
 
-    /*
+    /**
      * @var object	Reference to the task we're called with
      */
     private $task;


### PR DESCRIPTION
I accidental ran into this while checking my own codebase.