### PR TITLE
Missed property has been added back to class definition

### DIFF
--- a/classes/phing/tasks/ext/FileSyncTask.php
+++ b/classes/phing/tasks/ext/FileSyncTask.php
@@ -123,6 +123,12 @@ class FileSyncTask extends Task
     protected $defaultOptions = '-rpKzl';
 
     /**
+     * Command options.
+     * @var string
+     */
+    protected $options;
+
+    /**
      * Connection type.
      * @var boolean
      */


### PR DESCRIPTION
I've faced with tiny issue, that should be fixed 
`PHP Notice:  Undefined property: FileSyncTask::$options in /www/phing/classes/phing/tasks/ext/FileSyncTask.php on line 264`
