### PR TITLE
Static method call replaced in favor of dynamic 

### DIFF
--- a/classes/phing/tasks/ext/TarTask.php
+++ b/classes/phing/tasks/ext/TarTask.php
@@ -243,8 +243,9 @@ class TarTask extends MatchingTask
             $this->log("Building tar: " . $this->tarFile->__toString(), Project::MSG_INFO);
 
             $tar = new Archive_Tar($this->tarFile->getAbsolutePath(), $this->compression);
+            $pear = new PEAR();
 
-            if (PEAR::isError($tar->error_object)) {
+            if ($pear->isError($tar->error_object)) {
                 throw new BuildException($tar->error_object->getMessage());
             }
 
@@ -265,7 +266,7 @@ class TarTask extends MatchingTask
                 }
                 $tar->addModify($filesToTar, $this->prefix, $fsBasedir->getAbsolutePath());
 
-                if (PEAR::isError($tar->error_object)) {
+                if ($pear->isError($tar->error_object)) {
                     throw new BuildException($tar->error_object->getMessage());
                 }
             }


### PR DESCRIPTION
Improving compatibility with modern PHP versions 

Here fix for:
`PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /www/phing/classes/phing/tasks/ext/TarTask.php on line 247`
