### PR TITLE
Set ATTR_EMULATE_PREPARES => true for PgSQL connections

### DIFF
--- a/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxPgSQL.php
+++ b/classes/phing/tasks/ext/dbdeploy/DbmsSyntaxPgSQL.php
@@ -29,6 +29,14 @@
 class DbmsSyntaxPgSQL extends DbmsSyntax
 {
     /**
+     * @param \PDO $db
+     */
+    public function applyAttributes($db)
+    {
+        $db->setAttribute(\PDO::ATTR_EMULATE_PREPARES, true);
+    }
+
+    /**
      * @return string
      */
     public function generateTimestamp()


### PR DESCRIPTION
Hi all.
It is very important to set PDO::ATTR_EMULATE_PREPARES => true. Because some projects work with pgsql through pgBouncer (more information here https://pgbouncer.github.io/faq.html), and without this set we have an error like this

```
Previous exception 'PDOException' with message 'SQLSTATE[26000]: Invalid sql statement name: 7 ERROR:  prepared statement "pdo_stmt_00000001" does not exist' in /usr/share/php/phing/tasks/ext/dbdeploy/DbDeployTask.php:181
```

With this set attribute all connections through pgBouncer or direct to pgsql is work.

Thank you.
