### PR TITLE
Deal with cases where autoload isn't used

### DIFF
--- a/classes/phing/tasks/ext/phpunit/PHPUnitTask.php
+++ b/classes/phing/tasks/ext/phpunit/PHPUnitTask.php
@@ -450,12 +450,16 @@ class PHPUnitTask extends Task
         }
 
         $autoloadNew = spl_autoload_functions();
-        foreach ($autoloadNew as $autoload) {
-            spl_autoload_unregister($autoload);
+        if(is_array($autoloadNew)) {
+            foreach ($autoloadNew as $autoload) {
+                spl_autoload_unregister($autoload);
+            }
         }
 
-        foreach ($autoloadSave as $autoload) {
-            spl_autoload_register($autoload);
+        if(is_array($autoloadSave)) {
+            foreach ($autoloadSave as $autoload) {
+                spl_autoload_register($autoload);
+            }
         }
     }
 


### PR DESCRIPTION
I have code where I don't use autoloads. I cannot run the unit tests for this currently because I get the following error:

```
[zippy1981@basement test]$ ../bin/phing
Buildfile: /home/zippy1981/src/phing/test/build.xml

Phing Build Tests > initialize:


Phing Build Tests > configure:

     [echo] -------------------------------------------------
     [echo]  +++++ Running Phing  unit tests
     [echo] -------------------------------------------------

Phing Build Tests > reports:

   [delete] Deleting directory /home/zippy1981/src/phing/test/tmp
    [mkdir] Created dir: /home/zippy1981/src/phing/test/tmp
PHP Fatal error:  Call to undefined method PHPUnit_Util_Configuration::getSeleniumBrowserConfiguration() in /home/zippy1981/src/phing/classes/phing/tasks/ext/phpunit/PHPUnitTask.php on line 390
[zippy1981@basement test]$
```