### PR TITLE
Handle case where Linux-based OS is using a case-insensitive filesystem

### DIFF
--- a/classes/phing/tasks/ext/phpunit/PHPUnitTask.php
+++ b/classes/phing/tasks/ext/phpunit/PHPUnitTask.php
@@ -85,7 +85,9 @@ class PHPUnitTask extends Task
          * PEAR old-style, then composer, then PHAR
          */
         @include_once 'PHPUnit/Runner/Version.php';
-        @include_once 'phpunit/Runner/Version.php';
+        if (!class_exists('PHPUnit_Runner_Version')) {
+            @include_once 'phpunit/Runner/Version.php';
+        }
         if (!empty($this->pharLocation)) {
             $GLOBALS['_SERVER']['SCRIPT_NAME'] = '-';
             ob_start();


### PR DESCRIPTION
The Mac operating system can be set up with a filesystem that uses case-insensitive file names (specifically, the `Mac OS Extended (Journaled)` filesystem). Under this filesystem, `PHPUnit/Runner/Version.php`, and `phpunit/Runner/Version.php` refer to the same file. However, PHP does not recognize that this file has already been included, and attempts to include it again.

Here is the error that occurs (when the `@` operator is removed from `PHPUnitTask` [here](https://github.com/phingofficial/phing/blob/master/classes/phing/tasks/ext/phpunit/PHPUnitTask.php#L88)). Note that this is a fatal error that does not produce a `E_RECOVERABLE_ERROR`. As such, this task is unusable in this type of filesystem:

```
PHP Fatal error:  Cannot redeclare class PHPUnit_Runner_Version in /path/to/project/vendor/phpunit/phpunit/phpunit/Runner/Version.php on line 58
PHP Stack trace:
PHP   1. {main}() /path/to/project/vendor/phing/phing/bin/phing:0
PHP   2. require_once() /path/to/project/vendor/phing/phing/bin/phing:20
PHP   3. Phing::fire() /path/to/project/vendor/phing/phing/bin/phing.php:42
PHP   4. Phing::start() /path/to/project/vendor/phing/phing/classes/phing/Phing.php:295
PHP   5. Phing->runBuild() /path/to/project/vendor/phing/phing/classes/phing/Phing.php:170
PHP   6. Project->executeTargets() /path/to/project/vendor/phing/phing/classes/phing/Phing.php:630
PHP   7. Project->executeTarget() /path/to/project/vendor/phing/phing/classes/phing/Project.php:839
PHP   8. Target->performTasks() /path/to/project/vendor/phing/phing/classes/phing/Project.php:867
PHP   9. Target->main() /path/to/project/vendor/phing/phing/classes/phing/Target.php:373
PHP  10. Task->perform() /path/to/project/vendor/phing/phing/classes/phing/Target.php:343
PHP  11. UnknownElement->main() /path/to/project/vendor/phing/phing/classes/phing/Task.php:283
PHP  12. Blue\Deploy\BuildTask->main() /path/to/project/vendor/phing/phing/classes/phing/UnknownElement.php:101
PHP  13. include_once() /path/to/project/vendor/blue/deploy/src/MyTask.php:24
```

The PHP community [has recognized that this is not a bug with PHP](https://bugs.php.net/bug.php?id=51312), and so this case should be handled at the code/library level.

This also handles the case where the user has both `PHPUnit/Runner/Version.php` and `phpunit/Runner/Version.php` in different places on the include path in a case-sensitive filesystem.