### PR TITLE
Export ignore docs file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,7 @@ bin/* ident
 *.css ident
 *.xsl ident
 *.rng ident
-docs/api export-ignore
-docs/docbook5/en/source export-ignore
+docs export-ignore
 test export-ignore
 .travis.* export-ignore
 composer.lock export-ignore


### PR DESCRIPTION
The Docs folder, once downloaded is 5.64 MB, which is large when it is not a necessity