### PR TITLE
Exclude multiple files/directories

### DIFF
--- a/classes/phing/tasks/ext/SymfonyConsole/SymfonyConsoleTask.php
+++ b/classes/phing/tasks/ext/SymfonyConsole/SymfonyConsoleTask.php
@@ -35,7 +35,7 @@ class SymfonyConsoleTask extends Task
 
     /**
      *
-     * @var Array of Arg a collection of Arg objects
+     * @var Arg[] a collection of Arg objects
      */
     private $args = array();
 
@@ -49,7 +49,7 @@ class SymfonyConsoleTask extends Task
      *
      * @var string path to symfony console application
      */
-    private $console = 'php app/console';
+    private $console = 'app/console';
 
     /**
      *
@@ -197,7 +197,7 @@ class SymfonyConsoleTask extends Task
             $this->createArg()->setName("no-debug");
         }
         $cmd = array(
-            $this->console,
+            Commandline::quoteArgument($this->console),
             $this->command,
             implode(' ', $this->args)
         );


### PR DESCRIPTION
Use comma separated values to exclude multiple files/directories.
e.g.: `exclude="a,b" will produce command line `options --exclude="a" --exclude="b"`