### PR TITLE
Fix handling of line breaks on Windows in property files

### DIFF
--- a/classes/phing/system/io/IniFileParser.php
+++ b/classes/phing/system/io/IniFileParser.php
@@ -36,15 +36,15 @@ class IniFileParser implements FileParserInterface
      */
     public function parseFile(PhingFile $file)
     {
-        if (($lines = @file($file)) === false) {
+        if (($lines = @file($file, FILE_IGNORE_NEW_LINES)) === false) {
             throw new IOException("Unable to parse contents of $file");
         }
 
         // concatenate lines ending with backslash
         $linesCount = count($lines);
         for ($i = 0; $i < $linesCount; $i++) {
-            if (substr($lines[$i], -2, 1) === '\\') {
-                $lines[$i + 1] = substr($lines[$i], 0, -2) . ltrim($lines[$i + 1]);
+            if (substr($lines[$i], -1, 1) === '\\') {
+                $lines[$i + 1] = substr($lines[$i], 0, -1) . ltrim($lines[$i + 1]);
                 $lines[$i] = '';
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "sebastian/phpcpd": "2.x",
         "sebastian/git": "~1.0",
         "squizlabs/php_codesniffer": "~2.2",
-        "symfony/yaml": "~2.7"
+        "symfony/yaml": "~2.7",
+        "mikey179/vfsStream": "^1.6"
     },
     "autoload": {
         "classmap": ["classes/phing/"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ba2465b5e99edd4a98a0d163e61c14a7",
-    "content-hash": "36c8383c4353548dbaaf89472be6b635",
+    "hash": "bb0e28f3fa5d8147f5fa196c0686daf7",
+    "content-hash": "9e553d44e5c83476e8976db21e36fa3f",
     "packages": [],
     "packages-dev": [
         {
@@ -762,6 +762,52 @@
             "time": "2012-12-04 07:26:10"
         },
         {
+            "name": "mikey179/vfsStream",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikey179/vfsStream.git",
+                "reference": "fefd182fa739d4e23d9dc7c80d3344f528d600ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/fefd182fa739d4e23d9dc7c80d3344f528d600ab",
+                "reference": "fefd182fa739d4e23d9dc7c80d3344f528d600ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2016-01-13 09:41:49"
+        },
+        {
             "name": "monolog/monolog",
             "version": "1.17.2",
             "source": {
@@ -1046,7 +1092,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/HTTP_Request2/zipball/f36670a10bb9586d0e5f9d291f979cb6c8f94bfc",
+                "url": "https://api.github.com/repos/pear/HTTP_Request2/zipball/a1b3911bb041da571be2e5a46e6835670cdd2820",
                 "reference": "f36670a10bb9586d0e5f9d291f979cb6c8f94bfc",
                 "shasum": ""
             },
@@ -1100,7 +1146,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Net_Growl/zipball/845dac9651ef06337fb62ac51da1d4004081f767",
+                "url": "https://api.github.com/repos/pear/Net_Growl/zipball/b11fdbf93bb1adecb0cc6bda779e47ce54f3d526",
                 "reference": "845dac9651ef06337fb62ac51da1d4004081f767",
                 "shasum": ""
             },

--- a/test/classes/phing/system/io/IniFileParserTest.php
+++ b/test/classes/phing/system/io/IniFileParserTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+include_once 'phing/system/io/YamlFileParser.php';
+include_once 'phing/system/io/FileParserInterface.php';
+
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * @author Fabian Grutschus <fabian.grutschus@unister.de>
+ * @package phing.system.io
+ */
+class IniFileParserTest extends PHPUnit_Framework_TestCase
+{
+    private $parser;
+    private $root;
+
+    protected function setUp()
+    {
+        $this->parser = new IniFileParser();
+        $this->root = vfsStream::setup();
+    }
+
+    /**
+     * @dataProvider provideIniFiles
+     * @covers IniFileParser::parseFile
+     * @covers IniFileParser::inVal
+     */
+    public function testParseFile($data, $expected)
+    {
+        $file = $this->root->url() . '/test';
+        file_put_contents($file, $data);
+
+        $phingFile = new PhingFile($file);
+        $this->assertSame($expected, $this->parser->parseFile($phingFile));
+    }
+
+    /**
+     * @covers IniFileParser::parseFile
+     * @expectedException IOException
+     */
+    public function testParseFileCouldntOpenFile()
+    {
+        $phingFile = new PhingFile(uniqid());
+        $this->parser->parseFile($phingFile);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideIniFiles()
+    {
+        return array(
+            array(
+                'data'     => "property = test\nproperty2 = test2\nproperty3 = test3\n",
+                'expected' => array(
+                    'property'  => 'test',
+                    'property2' => 'test2',
+                    'property3' => 'test3',
+                ),
+            ),
+            array(
+                'data'     => "property = test\r\nproperty2 = test2\r\nproperty3 = test3\r\n",
+                'expected' => array(
+                    'property'  => 'test',
+                    'property2' => 'test2',
+                    'property3' => 'test3',
+                ),
+            ),
+            array(
+                'data'     => "property = test,\\\ntest2,\\\ntest3\n",
+                'expected' => array(
+                    'property' => 'test,test2,test3',
+                ),
+            ),
+            array(
+                'data'     => "property = test,\\\r\ntest2,\\\r\ntest3\r\n",
+                'expected' => array(
+                    'property' => 'test,test2,test3',
+                ),
+            ),
+            array(
+                'data'     => "# property = test",
+                'expected' => array(),
+            ),
+            array(
+                'data'     => "   # property = test",
+                'expected' => array(),
+            ),
+            array(
+                'data'     => "; property = test",
+                'expected' => array(),
+            ),
+            array(
+                'data'     => "property=test",
+                'expected' => array(
+                    'property' => 'test',
+                ),
+            ),
+            array(
+                'data'     => "property = true",
+                'expected' => array(
+                    'property' => true,
+                ),
+            ),
+            array(
+                'data'     => "property = false",
+                'expected' => array(
+                    'property' => false,
+                ),
+            ),
+        );
+    }
+}

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -25,6 +25,7 @@
     <filter>
         <whitelist>
             <directory suffix=".php">../classes/phing/tasks/</directory>
+            <directory suffix=".php">../classes/phing/system/</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
Fix handling of line breaks on Windows in property files.

```
someproperty = test,\\
test1,\\
test2
```

Didn't work when EOL is `\r\n`