### PR TITLE
Exclude multiple files/directories

### DIFF
--- a/classes/phing/tasks/ext/FileSyncTask.php
+++ b/classes/phing/tasks/ext/FileSyncTask.php
@@ -93,6 +93,7 @@ class FileSyncTask extends Task
 
     /**
      * Exclude file matching pattern.
+     * Use comma seperated values to exclude multiple files/directories, e.g.: a,b
      * @var string
      */
     protected $exclude;
@@ -297,7 +298,9 @@ class FileSyncTask extends Task
         }
 
         if ($this->exclude !== null) {
-            $options .= ' --exclude="' . $this->exclude . '"';
+            //remove trailing comma if any
+            $this->exclude = trim($this->exclude, ',');
+            $options .= ' --exclude="' . str_replace(',', '" --exclude="', $this->exclude) . '"';
         }
 
         if ($this->excludeFile !== null) {

--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -1036,7 +1036,9 @@
                     <row>
                         <entry><literal>exclude</literal></entry>
                         <entry><literal role="type">String</literal></entry>
-                        <entry>Excluded file matching pattern.</entry>
+                        <entry>Excluded file matching pattern. Use
+                        comma seperated values to exclude multiple
+                        files/directories, e.g.: a,b</entry>
                         <entry>n/a</entry>
                         <entry>No</entry>
                     </row>


### PR DESCRIPTION
Use comma separated values to exclude multiple files/directories.
e.g.: exclude="a,b" will produce command lineoptions --exclude="a" --exclude="b"`