### PR TITLE
Fix Windows encoding convertion

### DIFF
--- a/classes/phing/system/io/Win32FileSystem.php
+++ b/classes/phing/system/io/Win32FileSystem.php
@@ -630,7 +630,7 @@ class Win32FileSystem extends FileSystem
      */
     private function fixEncoding($strPath)
     {
-        $codepage = 'Windows-' . trim(strstr(setlocale(LC_CTYPE, 0), '.'), '.');
+        $codepage = 'CP' . trim(strstr(setlocale(LC_CTYPE, 0), '.'), '.');
         if (function_exists('iconv')) {
             $strPath = iconv('UTF-8', $codepage . '//IGNORE', $strPath);
         } elseif (function_exists('mb_convert_encoding')) {

--- a/classes/phing/system/io/Win32FileSystem.php
+++ b/classes/phing/system/io/Win32FileSystem.php
@@ -630,7 +630,7 @@ class Win32FileSystem extends FileSystem
      */
     private function fixEncoding($strPath)
     {
-        $codepage = 'CP' . trim(strstr(setlocale(LC_CTYPE, 0), '.'), '.');
+        $codepage = 'CP' . trim(strstr(setlocale(LC_CTYPE, ''), '.'), '.');
         if (function_exists('iconv')) {
             $strPath = iconv('UTF-8', $codepage . '//IGNORE', $strPath);
         } elseif (function_exists('mb_convert_encoding')) {


### PR DESCRIPTION
I got an error on run phing.

```
> phing prepare
Notice: iconv(): Wrong charset, conversion from `UTF-8' to `Windows-932//IGNORE' is not allowed in vendor\phing\phing\classes\phing\system\io\Win32FileSystem.php on line 635
Buildfile:  does not exist!
```

Now, phing use `iconv` or `mb_convert_encoding` for fixing windows encoding.
However, `Windows-${codepage}` is not usual codepage encoding format.

My `cmd.exe` use codepage 932.
`CP932` exists in supported encoding for `iconv` and `mbstring`, but `Windows-932` is not.
So, `fixEncoding` function failed and returned not string...

I request to use `CP` for encoding prefix.
Thanks!

## Refs

 * https://www.gnu.org/software/libiconv/
 * http://php.net/manual/ja/mbstring.supported-encodings.php