### PR TITLE
[#1259] Remove reference to PHP_CLASSPATH as an environment variable.

### DIFF
--- a/docs/docbook5/en/source/appendixes/factsheet.xml
+++ b/docs/docbook5/en/source/appendixes/factsheet.xml
@@ -95,7 +95,7 @@
 
                     <row>
                         <entry><literal>php.classpath</literal></entry>
-                        <entry>The value of the environment variable <literal>PHP_CLASSPATH</literal>.</entry>
+                        <entry>The value of the <literal>PHP_CLASSPATH</literal>. Same as the include path returned by get_include_path().</entry>
                     </row>
                     <row>
                         <entry><literal>php.version</literal></entry>

--- a/docs/docbook5/en/source/chapters/extending.xml
+++ b/docs/docbook5/en/source/chapters/extending.xml
@@ -906,9 +906,8 @@ class DOSMapper implements FileNameMapper {
         <sect2>
             <title> Using the Mapper </title>
             <para>Assuming that this mapper is saved to <literal>myapp/mappers/DOSMapper.php
-                </literal>(relative to a path on PHP's <literal>include_path</literal> or in
-                    <literal>PHP_CLASSPATH</literal> env variable), then you would refer to it like
-                this in your build file: </para>
+                </literal>(relative to a path on PHP's <literal>include_path</literal>,
+                    then you would refer to it like this in your build file: </para>
             <programlisting language="xml">&lt;mapper classname="myapp.mappers.DOSMapper"/></programlisting>
         </sect2>
     </sect1>

--- a/docs/docbook5/en/source/chapters/settingup.xml
+++ b/docs/docbook5/en/source/chapters/settingup.xml
@@ -273,12 +273,6 @@ $&gt; pear install phing/phing</screen>
                     binary is located (including the binary i.e. PHP_COMMAND=/usr/bin/php).</para>
             </listitem>
             <listitem>
-                <para>Set the <literal>PHP_CLASSPATH</literal> environment variable (see the section
-                    below). This should be set at least point to PHING_HOME/classes. Alternatively,
-                    you can also just add the phing/classes directory to your PHP include_path ini
-                    setting.</para>
-            </listitem>
-            <listitem>
                 <para>Check your php.ini file to make sure that you have the following
                     settings:</para>
                 <itemizedlist>
@@ -293,9 +287,6 @@ $&gt; pear install phing/phing</screen>
             </listitem>
         </itemizedlist>
 
-        <para>If you are using Phing in conjunction with another application, you may need to add
-            additional paths to <literal>PHP_CLASSPATH</literal>.</para>
-
         <sect2>
             <title> Unix </title>
 
@@ -305,7 +296,6 @@ $&gt; pear install phing/phing</screen>
 
             <screen>export PHP_COMMAND=/usr/bin/php
 export PHING_HOME=/opt/phing
-export PHP_CLASSPATH=${PHING_HOME}/classes
 export PATH=${PATH}:${PHING_HOME}/bin</screen>
         </sect2>
         <sect2>
@@ -316,7 +306,6 @@ export PATH=${PATH}:${PHING_HOME}/bin</screen>
 
             <screen>set PHP_COMMAND=c:\opt\php\php.exe
 set PHING_HOME=c:\opt\phing
-set PHP_CLASSPATH=c:\opt\phing\classes
 set PATH=%PATH%;%PHING_HOME%\bin</screen>
         </sect2>
         <sect2>
@@ -326,8 +315,7 @@ set PATH=%PATH%;%PHING_HOME%\bin</screen>
                 least the following:</para>
             <itemizedlist>
                 <listitem>
-                    <para>If you want Phing to be able to use other packages / classes, you can either add them to
-                        the <literal>PHP_CLASSPATH</literal> or to PHP's include_path.</para>
+                    <para>If you want Phing to be able to use other packages / classes, you can add them to PHP's include_path.</para>
                 </listitem>
                 <listitem>
                     <para>Some Tasks in <filename role="dir">phing/tasks/ext</filename> may require 3rd party


### PR DESCRIPTION
https://www.phing.info/trac/ticket/1259 - all references to PHP_CLASSPATH as an environment variable have now been removed.