### PR TITLE
Fixed getTaskName bug

### DIFF
--- a/classes/phing/UnknownElement.php
+++ b/classes/phing/UnknownElement.php
@@ -248,6 +248,8 @@ class UnknownElement extends Task
      */
     public function getTaskName()
     {
-        return $this->realThing === null ? parent::getTaskName() : $this->realThing->getTaskName();
+        return $this->realThing === null || !$this->realThing instanceof Task
+            ? parent::getTaskName()
+            : $this->realThing->getTaskName();
     }
 }


### PR DESCRIPTION
When executing the test build file with ProfileLogger enabled, it comes to an exception:
```
resolvepath: finished Sun, 04 Sep 2016 21:34:34 +0000 (0.0307 seconds)

path: started Sun, 04 Sep 2016 21:34:34 +0000

Fatal error: Uncaught Error: Call to undefined method Path::getTaskName() in xxx\classes\phing\UnknownElement.php on line 251

Error: Call to undefined method Path::getTaskName() in xxx\classes\phing\UnknownElement.php on line 251
```
Contribution would fix this behavior.