### PR TITLE
Fix fatal error in SassTask when scssphp is installed but the sass gem is not

### DIFF
--- a/classes/phing/tasks/ext/SassTask.php
+++ b/classes/phing/tasks/ext/SassTask.php
@@ -932,6 +932,7 @@ class SassTask extends Task
                     }
                 } else {
                     $lUseScssphp = true;
+                    $this->scssCompiler = $this->initialiseScssphp();
                 }
             }
         } elseif (!$this->useSass && !$this->useScssphp) {


### PR DESCRIPTION
This is a fix for issue 1262 (ref. https://www.phing.info/trac/ticket/1262)

When using the new SassTask with the default settings and having the scssphp package installed, but not the sass ruby gem, I'm getting the following fatal error:

```
PHP Fatal error:  Uncaught Error: Call to a member function compile() on null in /home/pieter/v/joinup/vendor/phing/phing/classes/phing/tasks/ext/SassTask.php:1105
Stack trace:
#0 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/tasks/ext/SassTask.php(1016): SassTask->compile('/home/pieter/v/...', '/home/pieter/v/...', true)
#1 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/tasks/ext/SassTask.php(976): SassTask->processFile(true)
#2 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/UnknownElement.php(100): SassTask->main()
#3 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/Task.php(283): UnknownElement->main()
#4 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/Target.php(336): Task->perform()
#5 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/Target.php(366): Target->main()
#6 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/Project.php(898): Target->performTasks()
#7 /home/pieter/v/joinup/vendor/phing/phing/classes/phing/Project.php(868): Project->executeTarget('compile-sass')
#8  in /home/pieter/v/joinup/vendor/phing/phing/classes/phing/tasks/ext/SassTask.php on line 1105
```

This happens because in the case that `sass` is not present but `scssphp` is, the variable `$lUseScsshp` is set, but `$this->scssCompiler` is not initialized.