### PR TITLE
Make SassTask compatible with PHP 7

### DIFF
--- a/classes/phing/tasks/ext/SassTask.php
+++ b/classes/phing/tasks/ext/SassTask.php
@@ -1213,17 +1213,10 @@ class SassTask extends Task
      */
     public function getNewCompiler()
     {
-        // Support for namespaces was added in PHP 5.3. Provide a fallback for
-        // PHP 5.2.
-        if (version_compare(PHP_VERSION, '5.3.0') < 0) {
-            $compiler = '\\Leafo\\ScssPhp\\Compiler';
-            $obj = call_user_func_array(
-                array($compiler, '__construct'),
-                array()
-            );
-            return self::$factory;
-        }
-        return new Leafo\ScssPhp\Compiler();
+        // Instantiate the class in a way that is compatible with
+        // PHP 5.2 up to 7.x.
+        $compiler = '\\Leafo\\ScssPhp\\Compiler';
+        return new $compiler;
     }
 
     /**

--- a/classes/phing/tasks/ext/SassTask.php
+++ b/classes/phing/tasks/ext/SassTask.php
@@ -1213,12 +1213,17 @@ class SassTask extends Task
      */
     public function getNewCompiler()
     {
-        $compiler = '\\Leafo\\ScssPhp\\Compiler';
-        $obj = call_user_func_array(
-            array($compiler, '__construct'),
-            array()
-        );
-        return self::$factory;
+        // Support for namespaces was added in PHP 5.3. Provide a fallback for
+        // PHP 5.2.
+        if (version_compare(PHP_VERSION, '5.3.0') < 0) {
+            $compiler = '\\Leafo\\ScssPhp\\Compiler';
+            $obj = call_user_func_array(
+                array($compiler, '__construct'),
+                array()
+            );
+            return self::$factory;
+        }
+        return new Leafo\ScssPhp\Compiler();
     }
 
     /**
@@ -1228,7 +1233,6 @@ class SassTask extends Task
      */
     public function initialiseScssphp()
     {
-        //$scss = new Leafo\ScssPhp\Compiler();
         $scss = $this->getNewCompiler();
         if ($this->style) {
             $ucStyle = ucfirst(strtolower($this->style));


### PR DESCRIPTION
The new SassTask is not compatible with PHP 7. Interestingly, earlier on in the development of the PR it was compatible, but at some point backwards compatibility with PHP 5.2 was added but this broke PHP 7.

This error occurs when trying to use the SassTask with scssphp on PHP 7:

> call_user_func_array() expects parameter 1 to be a valid callback, non-static method Leafo\ScssPhp\Compiler::__construct() cannot be called statically [line 1219 of /home/pieter/v/joinup/vendor/phing/phing/classes/phing/tasks/ext/SassTask.php]