### PR TITLE
Added optional use of an stylesheet [XmlLogger]

### DIFF
--- a/classes/phing/listener/XmlLogger.php
+++ b/classes/phing/listener/XmlLogger.php
@@ -144,6 +144,15 @@ class XmlLogger implements BuildLogger
      */
     public function buildFinished(BuildEvent $event)
     {
+        $xslUri = $event->getProject()->getProperty("phing.XmlLogger.stylesheet.uri");
+        if ($xslUri === null) {
+            $xslUri = "";
+        }
+
+        if ($xslUri !== '') {
+            $xslt = $this->doc->createProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="' . $xslUri . '"');
+            $this->doc->appendChild($xslt);
+        }
 
         $elapsedTime = Phing::currentTimeMillis() - $this->buildTimerStart;
 


### PR DESCRIPTION
Add an `xml-stylesheet` tag if property `phing.XmlLogger.stylesheet.uri` was set.