### PR TITLE
Fix missing include to FileParserFactory 

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -42,6 +42,7 @@ include_once 'phing/system/io/PhingFile.php';
 include_once 'phing/system/io/OutputStream.php';
 include_once 'phing/system/io/PrintStream.php';
 include_once 'phing/system/io/FileOutputStream.php';
+include_once 'phing/system/io/FileParserFactory.php';
 include_once 'phing/system/io/FileReader.php';
 include_once 'phing/system/util/Register.php';
 


### PR DESCRIPTION
When using directly the phar without composer autoload with the -propertyfile option, I was having a FATAL ERROR
$ php phing.phar -propertyfile config.ini help 
PHP Fatal error:  Class 'FileParserFactory' not found in phar:///home/workspace/phing.phar/classes/phing/Phing.php on line 515

It seems that in PR #488 , the include for class FileParserFactory was missing