### PR TITLE
PHP 5.x compatibility with Pear::isError

### DIFF
--- a/classes/phing/tasks/ext/PearPackage2Task.php
+++ b/classes/phing/tasks/ext/PearPackage2Task.php
@@ -285,7 +285,7 @@ class PearPackage2Task extends PearPackageTask
         $this->pkg->addRelease();
         $this->pkg->generateContents();
         $e = $this->pkg->writePackageFile();
-        if (PEAR::isError($e)) {
+        if (@PEAR::isError($e)) {
             throw new BuildException("Unable to write package file.", new Exception($e->getMessage()));
         }
     }

--- a/classes/phing/tasks/ext/PearPackageTask.php
+++ b/classes/phing/tasks/ext/PearPackageTask.php
@@ -154,7 +154,7 @@ class PearPackageTask extends MatchingTask
         // validation & return errors
         $e = $this->pkg->setOptions($this->preparedOptions);
 
-        if (PEAR::isError($e)) {
+        if (@PEAR::isError($e)) {
             throw new BuildException("Unable to set options.", new Exception($e->getMessage()));
         }
 
@@ -241,7 +241,7 @@ class PearPackageTask extends MatchingTask
         $this->setOptions();
 
         $e = $this->pkg->writePackageFile();
-        if (PEAR::isError($e)) {
+        if (@PEAR::isError($e)) {
             throw new BuildException("Unable to write package file.", new Exception($e->getMessage()));
         }
 

--- a/classes/phing/util/PearPackageScanner.php
+++ b/classes/phing/util/PearPackageScanner.php
@@ -187,7 +187,7 @@ class PearPackageScanner extends DirectoryScanner
             $pkg = new PEAR_PackageFile($config);
             $packageInfo = $pkg->fromPackageFile($this->packageFile, PEAR_VALIDATE_NORMAL);
             PEAR::staticPopErrorHandling();
-            if (PEAR::isError($packageInfo)) {
+            if (@PEAR::isError($packageInfo)) {
                 throw new BuildException("Errors in package file: " . $packageInfo->getMessage());
             }
         }


### PR DESCRIPTION
Corrects the "Non-static method PEAR::isError() should not be called statically"
Same fix as this one: https://www.phing.info/trac/ticket/460

This is the same pull request as #464 but with rebase.