### PR TITLE
Fixed referenced objects for PropertyTask

### DIFF
--- a/classes/phing/tasks/system/PropertyTask.php
+++ b/classes/phing/tasks/system/PropertyTask.php
@@ -329,8 +329,10 @@ class PropertyTask extends Task
 
                 if ($referencedObject instanceof Exception) {
                     $reference = $referencedObject->getMessage();
-                } else {
+                } elseif (method_exists($referencedObject, 'toString')) {
                     $reference = $referencedObject->toString();
+                } else {
+                    $reference = (string) $referencedObject;
                 }
 
                 $this->addProperty($this->name, $reference);
@@ -340,8 +342,10 @@ class PropertyTask extends Task
 
                     if ($referencedObject instanceof Exception) {
                         $reference = $referencedObject->getMessage();
-                    } else {
+                    } elseif (method_exists($referencedObject, 'toString')) {
                         $reference = $referencedObject->toString();
+                    } else {
+                        $reference = (string) $referencedObject;
                     }
                     $this->addProperty($this->name, $reference);
                 } else {


### PR DESCRIPTION
In case of a referenced `Path` object, PropertyTask tries to stringify the `Path` object by calling toString method, which is not available.