### PR TITLE
Added FileSet support to Path

### DIFF
--- a/classes/phing/types/Path.php
+++ b/classes/phing/types/Path.php
@@ -320,6 +320,15 @@ class Path extends DataType
                     $d = new PhingFile($dir, $dstr);
                     $result[] = $d->getAbsolutePath();
                 }
+            } elseif ($o instanceof FileSet) {
+                $fs = $o;
+                $ds = $fs->getDirectoryScanner($this->getProject());
+                $filestrs = $ds->getIncludedFiles();
+                $dir = $fs->getDir($this->getProject());
+                foreach ($filestrs as $fstr) {
+                    $d = new PhingFile($dir, $fstr);
+                    $result[] = $d->getAbsolutePath();
+                }
             } elseif ($o instanceof FileList) {
                 $fl = $o;
                 $dirstrs = $fl->getFiles($this->project);


### PR DESCRIPTION
Related to #546 to support the combination of `PathConvert` with `FileSet` and `Path`:

```
<fileset dir="${basedir}" id="src.files"/>
<pathconvert pathsep="," property="files" refid="src.files"/>
<echo>${files}</echo>
```

Property `files` can now be used as a set of files separated by colons to be used inside an `<arg>` element inside an `ExecTask`