### PR TITLE
Fix formated time

### DIFF
--- a/classes/phing/listener/DefaultLogger.php
+++ b/classes/phing/listener/DefaultLogger.php
@@ -305,8 +305,8 @@ class DefaultLogger implements StreamRequiredBuildLogger
     public static function formatTime($micros)
     {
         $seconds = $micros;
-        $minutes = $seconds / 60;
-        if ($minutes > 1) {
+        $minutes = (int)floor($seconds / 60);
+        if ($minutes >= 1) {
             return sprintf(
                 "%1.0f minute%s %0.2f second%s",
                 $minutes,


### PR DESCRIPTION
Rounding error results in DefaultLogger::formatTime(90) => "2 minutes 30.00 seconds" but should be "1 minute 30.00 seconds" instead.