### PR TITLE
Phing Strict Build Mode

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -107,6 +107,9 @@ class Phing
      */
     private $silent = false;
 
+    /** Indicates whether phing should run in strict mode */
+    private $strictMode = false;
+
     /** Indicates if this phing should be run */
     private $readyToRun = false;
 
@@ -497,6 +500,10 @@ class Phing
                 } else {
                     $this->loggerClassname = $args[++$i];
                 }
+            } elseif ($arg == "-no-strict") {
+              $this->strictMode = false;
+            } elseif ($arg == "-strict") {
+              $this->strictMode = true;
             } elseif ($arg == "-inputhandler") {
                 if ($this->inputHandlerClassname !== null) {
                     throw new ConfigurationException("Only one input handler class may be specified.");
@@ -662,7 +669,7 @@ class Phing
 
         $this->addBuildListeners($project);
         $this->addInputHandler($project);
-
+        
         // set this right away, so that it can be used in logging.
         $project->setUserProperty("phing.file", $this->buildFile->getAbsolutePath());
         $project->setUserProperty("phing.dir", dirname($this->buildFile->getAbsolutePath()));
@@ -701,6 +708,9 @@ class Phing
             throw $exc;
         }
 
+        // Set the project mode
+        $project->setStrictMode(StringHelper::booleanValue($this->strictMode));
+	
         // make sure that we have a target to execute
         if (count($this->targets) === 0) {
             $this->targets[] = $project->getDefaultTarget();
@@ -1012,8 +1022,13 @@ class Phing
         $msg .= "  -S -silent             print nothing but task outputs and build failures" . PHP_EOL;
         $msg .= "  -verbose               be extra verbose" . PHP_EOL;
         $msg .= "  -debug                 print debugging information" . PHP_EOL;
+<<<<<<< 3bb3a05724d2f45e9019aa8b2513298b11db4840
         $msg .= "  -emacs, -e             produce logging information without adornments" . PHP_EOL;
         $msg .= "  -diagnostics           print diagnostics information" . PHP_EOL;
+=======
+        $msg .= "  -strict                runs build in strict mode, considering a warning as error" . PHP_EOL;
+        $msg .= "  -no-strict             runs build normally. (overrides buildfile attribute)" . PHP_EOL;
+>>>>>>> - Added the functionality for 'Strict' mode within the system.
         $msg .= "  -longtargets           show target descriptions during build" . PHP_EOL;
         $msg .= "  -logfile <file>        use given file for log" . PHP_EOL;
         $msg .= "  -logger <classname>    the class which is to perform logging" . PHP_EOL;

--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -1022,13 +1022,10 @@ class Phing
         $msg .= "  -S -silent             print nothing but task outputs and build failures" . PHP_EOL;
         $msg .= "  -verbose               be extra verbose" . PHP_EOL;
         $msg .= "  -debug                 print debugging information" . PHP_EOL;
-<<<<<<< 3bb3a05724d2f45e9019aa8b2513298b11db4840
         $msg .= "  -emacs, -e             produce logging information without adornments" . PHP_EOL;
         $msg .= "  -diagnostics           print diagnostics information" . PHP_EOL;
-=======
         $msg .= "  -strict                runs build in strict mode, considering a warning as error" . PHP_EOL;
-        $msg .= "  -no-strict             runs build normally. (overrides buildfile attribute)" . PHP_EOL;
->>>>>>> - Added the functionality for 'Strict' mode within the system.
+        $msg .= "  -no-strict             runs build normally (overrides buildfile attribute)" . PHP_EOL;
         $msg .= "  -longtargets           show target descriptions during build" . PHP_EOL;
         $msg .= "  -logfile <file>        use given file for log" . PHP_EOL;
         $msg .= "  -logger <classname>    the class which is to perform logging" . PHP_EOL;

--- a/classes/phing/Project.php
+++ b/classes/phing/Project.php
@@ -104,6 +104,9 @@ class Project
     /** require phing version */
     private $phingVersion;
 
+    /** project strict mode */
+    private $strictMode = false;
+
     /** a FileUtils object */
     private $fileUtils;
 
@@ -521,6 +524,29 @@ class Project
         }
 
         return $this->phingVersion;
+    }
+
+    /**
+     * Sets the strict-mode (status) for the current project
+     * (If strict mode is On, all the warnings would be converted to an error
+     * (and the build will be stopped/aborted)
+     *
+     * @param    string $mode Strict-mode information
+     * @return   void
+     * @access   public
+     * @author   Utsav Handa, handautsav@hotmail.com
+     */
+    public function setStrictMode($strictmode) {
+        $this->strictMode = (bool) $strictmode;
+        $this->setProperty("phing.project.strictmode", $this->strictMode);
+    }
+
+    /**
+     * Get the strict-mode status for the project
+     * @return boolean
+     */
+    public function getStrictmode() {
+        return $this->strictMode;
     }
 
     /**
@@ -1169,6 +1195,13 @@ class Project
     public function logObject($obj, $msg, $level)
     {
         $this->fireMessageLogged($obj, $msg, $level);
+
+        // Checking whether the strict-mode is On, then consider all the warnings
+        // as errors.
+        if ( ($this->strictMode) && (Project::MSG_WARN == $level) ) {
+          throw new BuildException('Build contains warnings, considered as errors in strict mode', null);
+        }
+
     }
 
     /**

--- a/classes/phing/parser/ProjectHandler.php
+++ b/classes/phing/parser/ProjectHandler.php
@@ -78,6 +78,7 @@ class ProjectHandler extends AbstractHandler
         $desc = null;
         $baseDir = null;
         $ver = null;
+        $strict = null;
 
         // some shorthands
         $project = $this->configurator->project;
@@ -96,6 +97,8 @@ class ProjectHandler extends AbstractHandler
                 $desc = $value;
             } elseif ($key === "phingVersion") {
                 $ver = $value;
+            } elseif ($key === 'strict') {
+                $strict = $value;
             } else {
                 throw new ExpatParseException("Unexpected attribute '$key'");
             }
@@ -137,6 +140,10 @@ class ProjectHandler extends AbstractHandler
 
         if ($ver !== null) {
             $project->setPhingVersion($ver);
+        }
+
+        if($strict !== null) {
+            $project->setStrictMode(StringHelper::booleanValue($strict));
         }
 
         if ($project->getProperty("project.basedir") !== null) {

--- a/docs/docbook5/en/source/appendixes/projcomponents.xml
+++ b/docs/docbook5/en/source/appendixes/projcomponents.xml
@@ -89,6 +89,14 @@
                             <entry>n/a</entry>
                             <entry>No</entry>
                         </row>
+                        <row>
+                            <entry><literal>strict</literal></entry>
+                            <entry><literal role="type">Boolean</literal></entry>
+                            <entry>Enables the strict-mode for the project build process. If enabled, a warning would be
+                                considered as an error, and the build will be aborted.</entry>                
+                            <entry>false</entry>
+                            <entry>No</entry>
+                        </row>
                     </tbody>
                 </tgroup>
             </table>

--- a/docs/docbook5/en/source/chapters/gettingstarted.xml
+++ b/docs/docbook5/en/source/chapters/gettingstarted.xml
@@ -171,6 +171,11 @@
                             <entry>The description of the project.</entry>
                             <entry>No</entry>
                         </row>
+                        <row>
+                            <entry><literal>strict</literal></entry>
+                            <entry>Enables the strict-mode for the project build process.</entry>
+                            <entry>No</entry>
+                        </row>
                     </tbody>
                 </tgroup>
             </table>


### PR DESCRIPTION
Phing build would support a 'Strict' mode, which indicates to consider a warning as an error and raises a buildException to abort the build process.

**Ticket**
http://www.phing.info/trac/ticket/918

**Specs**
Phing build would support a 'Strict' mode, with the default value as Off (to enable backward compatibility until complete future migration). The 'strict' mode, when enabled, considers all the warnings (which are raised with "MSG_WARN" level) as an error, and raises a buildException to abort the build process.

This pull request adds the following functionalities:

1) The Project tag supports new attribute - strict (boolean), indicating the build process mode.

2) The Phing command-line utility would support two new parameters:
   -strict runs build in strict mode, considering a warning as error
   -no-strict runs build normally. (overrides build file attribute)

3) The command-line switches over-rides the 'Build File' "Project::Strict" attribute information.
   A sample target which builds in 'strict' mode:

```
<project name="PhingDev" basedir="./" default="help" strict="true" >

<property name="build.dir"  value="./" override="false" />

<!-- Target: HelloWorld -->
 <target name="helloworld">
   <echo msg="Hello, World" />
   <warn msg="${notdefined}" />
</target>

</project>
```

4) The documentation resources have been updated with the attribute information.

I understand, that the current Phing implementation does not consider the 'warnings' as a separate entity, but part of LogLevel. Therefore, currently, this implementation would have limited capability. But considering this as a starting point, we can utilize the future approach designing.

**Legacy PR**
#159 

Thanks,
Utsav
