### PR TITLE
Typo change execption to exception

### DIFF
--- a/classes/phing/BuildEvent.php
+++ b/classes/phing/BuildEvent.php
@@ -77,7 +77,7 @@ class BuildEvent extends EventObject
     protected $priority = Project::MSG_VERBOSE;
 
     /**
-     * The execption that caused the event, if any
+     * The exception that caused the event, if any
      *
      * @var    object
      */

--- a/classes/phing/parser/ProjectConfigurator.php
+++ b/classes/phing/parser/ProjectConfigurator.php
@@ -156,7 +156,7 @@ class ProjectConfigurator
      * Creates the ExpatParser, sets root handler and kick off parsing
      * process.
      *
-     * @throws BuildException if there is any kind of execption during
+     * @throws BuildException if there is any kind of exception during
      *                        the parsing process
      */
     protected function parse()


### PR DESCRIPTION
Minor mistype/swap of characters. Became aware of in one's of our own
projects in which phing was used so caught these as by-catch.

Via command line:

  find . -type f -name '*.php' -exec grep -q execption {} \; \
    -exec sed -i 's/execption/exception/g' {} \; -print

  ./classes/phing/BuildEvent.php
  ./classes/phing/parser/ProjectConfigurator.php