### PR TITLE
#633 - phive integration

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -81,7 +81,7 @@
         ==============================================
     -->
     <target name="setproperties">
-        
+
         <loadfile property="version" file="${phingpkg.home}/etc/VERSION.TXT"/>
 
         <property name="pkgname" value="phing-${version}"/>
@@ -137,6 +137,12 @@
             <fileset refid="all"/>
         </copy>
 
+        <copy file="${buildfile.dir}/manifest.xml" tofile="${build.full.dir}/manifest.xml">
+            <filterchain>
+                <expandproperties />
+            </filterchain>
+        </copy>
+
         <copy todir="${build.src.dir}">
             <fileset refid="classes"/>
             <fileset refid="etc"/>
@@ -165,7 +171,7 @@
         <phing phingfile="build.xml" dir="${phingpkg.home}/docs/api"
             target="build"
         />
-        
+
         <delete>
             <fileset dir=".">
                 <include name="*.log"/>
@@ -337,6 +343,7 @@
                 <include name="classes/**" />
                 <include name="etc/**" />
                 <include name="vendor/**" />
+                <include name="manifest.xml" />
             </fileset>
             <metadata>
                 <element name="version" value="${version}" />
@@ -402,8 +409,22 @@
     <target name="generate-hash">
         <filehash file="${filename}" algorithm="sha512" propertyname="phar.hash"/>
         <basename property="basefilename" file="${filename}"/>
-        <echo file="${filename}.sha512">${phar.hash} ${basefilename}
-</echo>
+        <echo file="${filename}.sha512">${phar.hash} ${basefilename}</echo>
+
+        <filehash file="${filename}" algorithm="sha384" propertyname="phar.hash"/>
+        <echo file="${filename}.sha384">${phar.hash} ${basefilename}</echo>
+
+        <filehash file="${filename}" algorithm="sha256" propertyname="phar.hash"/>
+        <echo file="${filename}.sha256">${phar.hash} ${basefilename}</echo>
+
+        <filehash file="${filename}" algorithm="sha1" propertyname="phar.hash"/>
+        <echo file="${filename}.sha1">${phar.hash} ${basefilename}</echo>
+
+        <exec command="gpg" checkreturn="true" logoutput="true">
+            <arg value="-u mrook@php.net --detach-sign --output" />
+            <arg path="${filename}.asc" />
+            <arg path="${filename}" />
+        </exec>
     </target>
 
 </project>

--- a/build/manifest.xml
+++ b/build/manifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phar xmlns="https://phar.io/xml/manifest/1.0">
+    <contains name="phing/phing" version="${version}" type="application"/>
+    <copyright>
+        <author name="Michiel Rook" email="mrook@php.net"/>
+        <license type="LGPL-3.0" url="https://github.com/phingofficial/phing/blob/master/LICENSE"/>
+    </copyright>
+    <requires>
+        <php version="^5.6"/>
+    </requires>
+</phar>


### PR DESCRIPTION
Fixes #633 

What will be needed during release:
- gpg key generated for `mrook@php.net`
- files that will be signed:
    - phing-*.phar
    - phing-*.tgz
    - phing-*.zip
- public key should be published on `hkps.pool.sks-keyservers.net`

Files that should be uploaded to GitHub releases:
- phing-*.phar
- phing-*.phar.asc
- phing-*.phar.sha1
- phing-*.phar.sha256
- phing-*.phar.sha384
- phing-*.phar.sha512 

More info: https://phar.io/howto/sign-and-upload-to-github.html