### PR TITLE
Fatal Error when pcntl extension isn't installed

### DIFF
--- a/classes/phing/contrib/DocBlox/Parallel/Manager.php
+++ b/classes/phing/contrib/DocBlox/Parallel/Manager.php
@@ -234,7 +234,9 @@ class DocBlox_Parallel_Manager extends ArrayObject
 
         /** @var DocBlox_Parallel_Worker $worker */
         foreach ($this as $worker) {
-            $worker->pipe->push();
+            if (isset($worker->pipe)) {
+                $worker->pipe->push();
+            }
         }
 
         $this->is_running = false;


### PR DESCRIPTION
When the pcntl extension isn\'t installed, then the DocBlox_Parallel_Manager doesn't create the pipe property. In stopExecution() the Manager tries to call the push method on an undefined propety.

I have added a simple isset before the call.