### PR TITLE
file_get_contents in windows return a permission error if the file is  a dir

### DIFF
--- a/classes/phing/util/FileUtils.php
+++ b/classes/phing/util/FileUtils.php
@@ -427,6 +427,10 @@ class FileUtils
             return false;
         }
 
+        if ($file1->isDirectory() || $file2->isDirectory()) {
+            return false;
+        }
+
         $c1 = file_get_contents($file1->getAbsolutePath());
         $c2 = file_get_contents($file2->getAbsolutePath());
 

--- a/test/classes/phing/tasks/condition/FilesMatchTest.php
+++ b/test/classes/phing/tasks/condition/FilesMatchTest.php
@@ -28,4 +28,10 @@ class FilesMatchTest extends BuildFileTest
         $this->executeTarget(__FUNCTION__);
         $this->assertPropertyUnset('unset');
     }
+
+    public function testDirectoryMatches()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertPropertyUnset('directory');
+    }
 }

--- a/test/etc/tasks/system/FilesMatchTest.xml
+++ b/test/etc/tasks/system/FilesMatchTest.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="FilesMatchTest" default="testFilesMatches">
     <target name="testFileMatches">
-    	<condition property="matches">
-    	    <filesmatch file1="${phing.home}/README.md" file2="${phing.home}/README.md"/>
-    	</condition>
+        <condition property="matches">
+            <filesmatch file1="${phing.home}/README.md" file2="${phing.home}/README.md"/>
+        </condition>
     </target>
     <target name="testNoFileMatches">
         <condition property="unset">
             <filesmatch file1="${phing.home}/README.md" file2="${phing.home}/LICENSE"/>
+        </condition>
+    </target>
+    <target name="testDirectoryMatches">
+        <condition property="directory">
+            <filesmatch file1="${phing.home}/test" file2="${phing.home}/test"/>
         </condition>
     </target>
 </project>


### PR DESCRIPTION
Check if one of the files is a dir before file_get_contents