### PR TITLE
Add possibility to set the phing.dir with a environment variable.

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -567,6 +567,8 @@ class Phing
             // but -find then search for it
             if ($this->searchForThis !== null) {
                 $this->buildFile = $this->_findBuildFile(self::getProperty("user.dir"), $this->searchForThis);
+            } else if (getenv("PHING_DIR")) {
+                $this->buildFile = new PhingFile(getenv("PHING_DIR"), self::DEFAULT_BUILD_FILENAME);
             } else {
                 $this->buildFile = new PhingFile(self::DEFAULT_BUILD_FILENAME);
             }


### PR DESCRIPTION
This will allow to execute phing projects globally. So I can do something like that on my custom phing project installed globally.

```
#!/usr/bin/env php
<?php

/**
 * Shell wrapper for Phing
 */

// turn off html errors
ini_set('html_errors', 'off');

define('BP', realpath(dirname(__DIR__)));

putenv("PHING_DIR=".BP);
putenv("PHING_HOME=" . BP . '/vendor/phing/phing');

require_once getenv("PHING_HOME") . '/bin/phing.php';
```
