### PR TITLE
Fixed clone method in dirset. Related to #649

### DIFF
--- a/classes/phing/types/DirSet.php
+++ b/classes/phing/types/DirSet.php
@@ -46,9 +46,9 @@ class DirSet extends AbstractFileSet
     public function __clone()
     {
         if ($this->isReference()) {
-            return new DirSet($this->getRef($this->getProject()));
+            new DirSet($this->getRef($this->getProject()));
         } else {
-            return new DirSet($this);
+            new DirSet($this);
         }
     }
 


### PR DESCRIPTION
Related to #649 :
Removed the return statements inside the `__clone` method.