### PR TITLE
Preinstantiating location in constructor. Related to #649

### DIFF
--- a/classes/phing/ProjectComponent.php
+++ b/classes/phing/ProjectComponent.php
@@ -36,10 +36,17 @@ abstract class ProjectComponent
      */
     protected $project = null;
 
+    /** @var Location $location */
     private $location;
-    
+
+    /** @var string $description */
     private $description;
-    
+
+    public function __construct()
+    {
+        $this->location = new Location();
+    }
+
     /**
      * References the project to the current component.
      *


### PR DESCRIPTION
Related to #649 :
`ProjectComponent` should hold an instance of `Location`.