### PR TITLE
Output of jslint report wasn't being parsed correctly by jshint.

### DIFF
--- a/classes/phing/tasks/ext/JsHintTask.php
+++ b/classes/phing/tasks/ext/JsHintTask.php
@@ -213,10 +213,11 @@ class JsHintTask extends Task
         $projectBasedir = $this->_getProjectBasedir();
         $errorsCount = 0;
         $warningsCount = 0;
+        $fileError = $this->xmlAttributes['fileError'];
         foreach ($xml->file as $file) {
             $fileAttributes = $file->attributes();
             $fileName = (string) $fileAttributes['name'];
-            foreach ($file->error as $error) {
+            foreach ($file->$fileError as $error) {
                 $errAttr = (array) $error->attributes();
                 $attrs = current($errAttr);
 


### PR DESCRIPTION
issues/errors included in jslint styled reports are on "<issue>" XML elements not "<error>" elements and so were being skipped over.

This PR fixes that problem.