### PR TITLE
Fix invalid usage of isset on a property in parallel task

### DIFF
--- a/classes/phing/contrib/DocBlox/Parallel/Manager.php
+++ b/classes/phing/contrib/DocBlox/Parallel/Manager.php
@@ -234,7 +234,7 @@ class DocBlox_Parallel_Manager extends ArrayObject
 
         /** @var DocBlox_Parallel_Worker $worker */
         foreach ($this as $worker) {
-            if (isset($worker->pipe)) {
+            if (isset($worker->pipe) && null !== $worker->pipe) {
                 $worker->pipe->push();
             }
         }


### PR DESCRIPTION
Its not enough to check for `isset($worker->pipe)` on property. This fixes Call to a member function push() on null in ... Manager.php:237 #706