### PR TITLE
Fix for issue #771 - VersionTask output file contains trailing new line character

### DIFF
--- a/classes/phing/tasks/ext/VersionTask.php
+++ b/classes/phing/tasks/ext/VersionTask.php
@@ -155,7 +155,7 @@ class VersionTask extends Task
             }
         } else {
             // write new Version to file
-            file_put_contents($this->file, $newVersion . $this->getProject()->getProperty('line.separator'));
+            file_put_contents($this->file, $newVersion);
         }
 
         //Finally set the property

--- a/test/classes/phing/tasks/ext/VersionTaskTest.php
+++ b/test/classes/phing/tasks/ext/VersionTaskTest.php
@@ -64,6 +64,7 @@ class VersionTaskTest extends BuildFileTest
         $this->executeTarget(__FUNCTION__);
         $this->assertPropertyEquals('build.version', '1.0.0');
         $this->assertFileExists(PHING_TEST_BASE . "/etc/tasks/ext/" . 'build.version', 'File not found');
+        $this->assertStringEqualsFile(PHING_TEST_BASE . "/etc/tasks/ext/" . 'build.version', '1.0.0', 'File contents not correct');
     }
 
     public function testPropFile()


### PR DESCRIPTION
updated VersionTaskTest to reproduce issue #771
update to VersionTask to no longer append the property line separator to the resulting version file, test passes