### PR TITLE
Added missing constructor call.

### DIFF
--- a/classes/phing/tasks/system/ConditionTask.php
+++ b/classes/phing/tasks/system/ConditionTask.php
@@ -45,6 +45,14 @@ class ConditionTask extends ConditionBase
 
     /** @var string $alternative */
     private $alternative;
+
+    /**
+     * Constructor, names this task "condition".
+     */
+    public function __construct()
+    {
+        parent::__construct('condition');
+    }
     
     /**
      * The name of the property to set. Required.


### PR DESCRIPTION
Fixes the correct task name for conditions.