### PR TITLE
Fixed usage of filelist if PathConvert uses a reference.

### DIFF
--- a/classes/phing/tasks/system/PathConvert.php
+++ b/classes/phing/tasks/system/PathConvert.php
@@ -221,6 +221,10 @@ class PathConvert extends Task
                 $ds = $obj;
 
                 $this->path->addDirset($ds);
+            } elseif ($obj instanceof FileList) {
+                $fl = $obj;
+
+                $this->path->addFilelist($fl);
             } else {
                 throw new BuildException("'refid' does not refer to a "
                     . "path, fileset, dirset, or "


### PR DESCRIPTION
Added missing `Path::addFilelist()` when used as reference.