### PR TITLE
Added LZMA2 algorithm support for TarTask

### DIFF
--- a/classes/phing/tasks/ext/TarTask.php
+++ b/classes/phing/tasks/ext/TarTask.php
@@ -174,6 +174,9 @@ class TarTask extends MatchingTask
             case "bzip2":
                 $this->compression = "bz2";
                 break;
+            case "lzma2":
+                $this->compression = "lzma2";
+                break;
             case "none":
                 $this->compression = null;
                 break;

--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -13031,7 +13031,7 @@ host="webserver" command="ls" /></programlisting>
                     <row>
                         <entry><literal>compression</literal></entry>
                         <entry><literal role="type">String</literal></entry>
-                        <entry>Type of compression to use (gzip, bzip2, none)</entry>
+                        <entry>Type of compression to use (gzip, bzip2, lzma2, none)</entry>
                         <entry>none</entry>
                         <entry>No</entry>
                     </row>

--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -5785,6 +5785,7 @@
                         <choice>
                             <value>gzip</value>
                             <value>bzip2</value>
+                            <value>lzma2</value>
                             <value>none</value>
                         </choice>
                     </attribute>


### PR DESCRIPTION
Since TarTask is based on "pear/Archive_Tar" and the latter is capable of creating lzma2-compressed archives I've exposed an option to create such archives.