### PR TITLE
Fix: php.ini variable evaluation and "Notice: A non well formed numeric value encountered"

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -1580,21 +1580,23 @@ class Phing
      * @param string $val
      * @return int
      */
-    private static function convertShorthand($val)
+    public static function convertShorthand($val)
     {
         $val = trim($val);
         $last = strtolower($val[strlen($val) - 1]);
 
-        $val = (int) $val;
+        if (!is_numeric($last)) {
+            $val = (int) substr($val, 0, strlen($val) - 1);
 
-        switch ($last) {
-            // The 'G' modifier is available since PHP 5.1.0
-            case 'g':
-                $val *= 1024;
-            case 'm':
-                $val *= 1024;
-            case 'k':
-                $val *= 1024;
+            switch ($last) {
+                // The 'G' modifier is available since PHP 5.1.0
+                case 'g':
+                    $val *= 1024;
+                case 'm':
+                    $val *= 1024;
+                case 'k':
+                    $val *= 1024;
+            }
         }
 
         return $val;

--- a/test/classes/phing/PhingTest.php
+++ b/test/classes/phing/PhingTest.php
@@ -68,6 +68,25 @@ class PhingTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test the convertShorthand function 
+     */
+    public function testConvertShorthand()
+    {
+        self::assertEquals(0, Phing::convertShorthand('0'));
+        self::assertEquals(-1, Phing::convertShorthand('-1'));
+        self::assertEquals(100, Phing::convertShorthand('100'));
+        self::assertEquals(1024, Phing::convertShorthand('1k'));
+        self::assertEquals(1024, Phing::convertShorthand('1K'));
+        self::assertEquals(2048, Phing::convertShorthand('2K'));
+        self::assertEquals(1048576, Phing::convertShorthand('1M'));
+        self::assertEquals(1048576, Phing::convertShorthand('1m'));
+        self::assertEquals(1073741824, Phing::convertShorthand('1G'));
+        self::assertEquals(1073741824, Phing::convertShorthand('1g'));
+
+        self::assertEquals(200, Phing::convertShorthand('200j'));
+    }
+
+    /**
      * Get fixtures classpath
      *
      * @return string Classpath


### PR DESCRIPTION
The php.ini can contain values like: '1K' (as 1 kilobyte) instead of '1024' or '1M' as (1 megabyte) instead of '1048576'.
For example:
memory_limit = 32M
post_max_size = 32M

Phing is buggy as '1M' is handled as same as '1K'.

Additionally $val = '2k' * 1024 cause a "Notice: A non well formed numeric value encountered".
Before PHP 7 it was ignored and handled as 2 * 1024.