### PR TITLE
Fixed log method - HttpGetTask.

### DIFF
--- a/classes/phing/tasks/ext/HttpGetTask.php
+++ b/classes/phing/tasks/ext/HttpGetTask.php
@@ -198,10 +198,10 @@ class HttpGetTask extends HttpTask
         $this->quiet = $v;
     }
 
-    public function log($msg, $msgLevel = Project::MSG_INFO)
+    public function log($msg, $msgLevel = Project::MSG_INFO, Exception $t = null)
     {
         if (!$this->quiet || $msgLevel <= Project::MSG_ERR) {
-            parent::log($msg, $msgLevel);
+            parent::log($msg, $msgLevel, $t);
         }
     }
 }


### PR DESCRIPTION
Added missing exception argument to the log method.
Related to #760 