### PR TITLE
Added negate attribute to the `linecontains` filter.

### DIFF
--- a/docs/docbook5/en/source/appendixes/corefilters.xml
+++ b/docs/docbook5/en/source/appendixes/corefilters.xml
@@ -300,6 +300,35 @@
   &lt;/linecontains>
 &lt;/filterchain></programlisting>
 
+        <table>
+            <title> Attributes for the <literal>&lt;linecontains> </literal>filter </title>
+            <tgroup cols="5">
+                <colspec colname="name" colnum="1" colwidth="1.5*"/>
+                <colspec colname="type" colnum="2" colwidth="0.8*"/>
+                <colspec colname="description" colnum="3" colwidth="3.5*"/>
+                <colspec colname="default" colnum="4" colwidth="0.8*"/>
+                <colspec colname="required" colnum="5" colwidth="1.2*"/>
+                <thead>
+                    <row>
+                        <entry>Name</entry>
+                        <entry>Type</entry>
+                        <entry>Description</entry>
+                        <entry>Default</entry>
+                        <entry>Required</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry><literal>negate</literal></entry>
+                        <entry><literal role="type">Boolean</literal></entry>
+                        <entry>Whether to select non-matching lines only.</entry>
+                        <entry>false</entry>
+                        <entry>No</entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+
         <sect2>
             <title>Nested tags</title>
 

--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -6290,6 +6290,11 @@
     </define>
 
     <define name="linecontains">
+        <optional>
+            <attribute name="negate" a:defaultValue="false">
+                <data type="boolean"/>
+            </attribute>
+        </optional>
         <element name="linecontains">
             <oneOrMore>
                 <ref name="contains"/>

--- a/test/classes/phing/filters/LineContainsTest.php
+++ b/test/classes/phing/filters/LineContainsTest.php
@@ -50,4 +50,13 @@ class LineContainsTest extends BuildFileTest
         $result = $this->getProject()->resolveFile("result/linecontains.test");
         $this->assertTrue($this->fu->contentEquals($expected, $result), "Files don't match!");
     }
+
+    public function testLineContainsNegate()
+    {
+        $this->executeTarget(__FUNCTION__);
+
+        $expected = $this->getProject()->resolveFile("expected/linecontains-negate.test");
+        $result = $this->getProject()->resolveFile("result/linecontains.test");
+        $this->assertTrue($this->fu->contentEquals($expected, $result), "Files don't match!");
+    }
 }

--- a/test/etc/filters/expected/linecontains-negate.test
+++ b/test/etc/filters/expected/linecontains-negate.test
@@ -1,0 +1,2 @@
+This is line 1 with alpha.
+This is line 3 with gamma.

--- a/test/etc/filters/linecontains.xml
+++ b/test/etc/filters/linecontains.xml
@@ -20,4 +20,16 @@
     </copy>
   </target>
 
+  <target name="testLineContainsNegate" depends="init">
+    <copy todir="result">
+      <fileset dir="input"/>
+      <filterchain>
+        <filterreader classname="phing.filters.LineContains">
+          <param type="contains" value="beta"/>
+          <param type="negate" value="true"/>
+        </filterreader>
+      </filterchain>
+    </copy>
+  </target>
+
 </project>


### PR DESCRIPTION
Example getting all non-matching lines:
```xml
<filterreader classname="phing.filters.LineContains">
      <param type="contains" value="beta"/>
      <param type="negate" value="true"/>
</filterreader>
```
