### PR TITLE
Add new example for PdoSqlTask

### DIFF
--- a/docs/docbook5/en/source/appendixes/optionaltasks.xml
+++ b/docs/docbook5/en/source/appendixes/optionaltasks.xml
@@ -7009,6 +7009,14 @@ Note that you can omit both startpoint and track attributes in this case
   &lt;transaction src="path/to/sqlfile.sql"/>
   &lt;formatter type="plain" outfile="path/to/output.txt"/>
   &lt;/pdosqlexec></programlisting>
+            <programlisting language="xml">&lt;property name="color" value="orange"/>
+&lt;pdosqlexec url="mysql:host=localhost;dbname=test"
+            userid="username" password="password">
+    &lt;transaction>
+        SELECT * FROM products WHERE color = '${color}';
+    &lt;/transaction>
+    &lt;formatter type="xml" outfile="path/to/output.xml"/>
+&lt;/pdosqlexec></programlisting>
             <note>
                 <para>Because of backwards compatibility, the PDOSQLExecTask can also be called using
                     the <literal>'pdo'</literal> statement.</para>


### PR DESCRIPTION
This new example shows how you can use SQL directly into your buildfile. 
The query uses the `${color}` property, once executed the result is saved on xml format.

```sql
<property name="color" value="orange"/>
<pdosqlexec url="mysql:host=localhost;dbname=test"
            userid="username" password="password">
    <transaction>
        SELECT * FROM products WHERE color = '${color}';
    </transaction>
    <formatter type="xml" outfile="path/to/output.xml"/>
</pdosqlexec>
```