### PR TITLE
Add new example for Available condition

### DIFF
--- a/docs/docbook5/en/source/chapters/projcomponents.xml
+++ b/docs/docbook5/en/source/chapters/projcomponents.xml
@@ -880,6 +880,12 @@
                     >Available</link> task, all attributes and nested elements of that task are
                 supported, the property and value attributes are redundant and will be
                 ignored.</para>
+            <programlisting language="xml">&lt;if>
+    &lt;available file="README.md"/>
+    &lt;then>
+        &lt;echo message="Please read README.md"/>
+    &lt;/then>
+&lt;/if></programlisting>
         </sect2>
         <sect2 xml:id="conditions.filesmatch">
             <title><literal>filesmatch</literal></title>


### PR DESCRIPTION
Since `available` condition has no examples I wrote one:

```sql
<if>
    <available file="README.md"/>
    <then>
        <echo message="Please read README.md"/>
    </then>
</if>
```

In this example I check the availability of `README.md` file to echo a message.
I deliberately omitted the `property` and `value` attributes which are mandatory for `AvailableTask` but are ignored by `available` condition.