### PR TITLE
Doc: add phing.startTime built-in property

### DIFF
--- a/docs/docbook5/en/source/appendixes/factsheet.xml
+++ b/docs/docbook5/en/source/appendixes/factsheet.xml
@@ -85,6 +85,10 @@
                         <entry>Phing installation directory, not set in PEAR installations.</entry>
                     </row>
                     <row>
+                        <entry><literal>phing.startTime</literal></entry>
+                        <entry>The time that Phing started to run.</entry>
+                    </row>
+                    <row>
                         <entry><literal>phing.version</literal></entry>
                         <entry>Current Phing version.</entry>
                     </row>


### PR DESCRIPTION
It seems `phing.startTime` built-in property [exists since 2008](https://www.phing.info/trac/ticket/255).
I think this property can be useful for others, therefor I added it to documentation.