### PR TITLE
Target attrib of PhingTask must not be empty.

### DIFF
--- a/classes/phing/tasks/system/PhingTask.php
+++ b/classes/phing/tasks/system/PhingTask.php
@@ -563,10 +563,14 @@ class PhingTask extends Task
      * The target of the new Phing project to execute.
      * Defaults to the new project's default target.
      *
-     * @param $s
+     * @param string $s
      */
-    public function setTarget($s)
+    public function setTarget(string $s)
     {
+        if ('' === $s) {
+            throw new BuildException("target attribute must not be empty");
+        }
+
         $this->newTarget = $s;
     }
 


### PR DESCRIPTION
Be more strict on adding an empty string as target name.