### PR TITLE
Fixed grammar for phpdoc2 task.

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -4755,7 +4755,10 @@
                     <attribute name="destdir"/>
                 </optional>
                 <optional>
-                    <attribute name="output"/>
+                    <choice>
+                        <attribute name="destdir"/>
+                        <attribute name="output"/>
+                    </choice>
                 </optional>
                 <optional>
                     <attribute name="template"/>


### PR DESCRIPTION
We can choose between `output` and `destdir` attributes.