### PR TITLE
Add delta to foreachtask in loop

### DIFF
--- a/classes/phing/tasks/system/ForeachTask.php
+++ b/classes/phing/tasks/system/ForeachTask.php
@@ -63,6 +63,9 @@ class ForeachTask extends Task
     /** Delimiter that separates items in $list */
     private $delimiter = ',';
 
+    /** Delimiter that separates items in $list */
+    private $delta = 'delta';
+
     /**
      * PhingCallTask that will be invoked w/ calleeTarget.
      * @var PhingCallTask
@@ -139,7 +142,7 @@ class ForeachTask extends Task
             $arr = explode($this->delimiter, $this->list);
             $total_entries = 0;
 
-            foreach ($arr as $value) {
+            foreach ($arr as $delta => $value) {
                 $value = trim($value);
                 $premapped = '';
                 if ($mapper !== null) {
@@ -158,6 +161,10 @@ class ForeachTask extends Task
                 $prop->setOverride(true);
                 $prop->setName($this->param);
                 $prop->setValue($value);
+                $prop = $callee->createProperty();
+                $prop->setOverride(true);
+                $prop->setName($this->delta);
+                $prop->setValue($delta);
                 $callee->main();
                 $total_entries++;
             }

--- a/classes/phing/tasks/system/ForeachTask.php
+++ b/classes/phing/tasks/system/ForeachTask.php
@@ -331,6 +331,14 @@ class ForeachTask extends Task
     }
 
     /**
+     * @param $delta
+     */
+    public function setDelta($delta)
+    {
+      $this->delta = (string) $delta;
+    }
+
+  /**
      * Nested adder, adds a set of files (nested fileset attribute).
      *
      * @param FileSet $fs


### PR DESCRIPTION
This allows the user to use the delta of the foreach loop within the called phing task. The default property name for the delta is "delta", but could be overridden with in the foreach call.