### PR TITLE
Fixed #712

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,9 @@ Vagrant.configure(2) do |config|
   if which('ansible-playbook')
       config.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible/playbook.yml"
+        ansible.extra_vars = {
+          ansible_python_interpreter: "/usr/bin/python3"
+        }
         ansible.tags     = "vagrant"
       end
   else


### PR DESCRIPTION
Added
```
ansible.extra_vars = {
    ansible_python_interpreter: "/usr/bin/python3"
}
```
to the `Vagrantfile` - related to #712 