### PR TITLE
Skip tests

### DIFF
--- a/classes/phing/tasks/ext/phar/PharPackageTask.php
+++ b/classes/phing/tasks/ext/phar/PharPackageTask.php
@@ -334,6 +334,12 @@ class PharPackageTask extends MatchingTask
      */
     private function checkPreconditions()
     {
+        if (ini_get('phar.readonly') == "1") {
+            throw new BuildException(
+                "PharPackageTask require phar.readonly php.ini setting to be disabled"
+            );
+        }
+
         if (!extension_loaded('phar')) {
             throw new BuildException(
                 "PharPackageTask require either PHP 5.3 or better or the PECL's Phar extension"

--- a/test/classes/phing/regression/ExcludeZipTest.php
+++ b/test/classes/phing/regression/ExcludeZipTest.php
@@ -29,6 +29,9 @@ class ExcludeZipTest extends BuildFileTest
 {
     public function setUp()
     {
+        if (!extension_loaded('zip')) {
+            $this->markTestSkipped("Zip extension is required");
+        }
         $this->configureProject(PHING_TEST_BASE . "/etc/regression/137/build.xml");
     }
 

--- a/test/classes/phing/tasks/ext/DbDeployTaskTest.php
+++ b/test/classes/phing/tasks/ext/DbDeployTaskTest.php
@@ -27,6 +27,10 @@ class DbDeployTaskTest extends BuildFileTest
 {
     public function setUp()
     {
+        if (!extension_loaded('sqlite')) {
+            $this->markTestSkipped('This test require sqlite extension to be loaded');
+        }
+
         $this->configureProject(PHING_TEST_BASE . "/etc/tasks/ext/dbdeploy/build.xml");
         $this->executeTarget("prepare");
     }

--- a/test/classes/phing/tasks/ext/HgTasks/HgCloneTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgCloneTaskTest.php
@@ -2,6 +2,8 @@
 
 class HgCloneTaskTest extends BuildFileTest
 {
+    use HgTaskTestSkipper;
+
     public function setUp()
     {
         $this->configureProject(
@@ -12,6 +14,8 @@ class HgCloneTaskTest extends BuildFileTest
 
     public function testWrongRepository()
     {
+        $this->markTestAsSkippedWhenHgNotInstalled();
+
         $this->expectBuildExceptionContaining(
             'wrongRepository',
             'wrong repository',

--- a/test/classes/phing/tasks/ext/HgTasks/HgCloneTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgCloneTaskTest.php
@@ -2,7 +2,7 @@
 
 class HgCloneTaskTest extends BuildFileTest
 {
-    use HgTaskTestSkipper;
+    use HgTaskTestSkip;
 
     public function setUp()
     {

--- a/test/classes/phing/tasks/ext/HgTasks/HgInitTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgInitTaskTest.php
@@ -2,6 +2,8 @@
 
 class HgInitTaskTest extends BuildFileTest
 {
+    use HgTaskTestSkipper;
+
     public function setUp()
     {
         mkdir(PHING_TEST_BASE . '/tmp/hgtest');
@@ -15,8 +17,11 @@ class HgInitTaskTest extends BuildFileTest
     {
         $this->rmdir(PHING_TEST_BASE . "/tmp/hgtest");
     }
+
     public function testHgInit()
     {
+        $this->markTestAsSkippedWhenHgNotInstalled();
+
         $repository = PHING_TEST_BASE . '/tmp/hgtest';
         $HGdir = $repository . '/.hg';
         $this->executeTarget('hgInit');

--- a/test/classes/phing/tasks/ext/HgTasks/HgInitTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgInitTaskTest.php
@@ -2,7 +2,7 @@
 
 class HgInitTaskTest extends BuildFileTest
 {
-    use HgTaskTestSkipper;
+    use HgTaskTestSkip;
 
     public function setUp()
     {

--- a/test/classes/phing/tasks/ext/HgTasks/HgPullTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgPullTaskTest.php
@@ -2,7 +2,7 @@
 
 class HgPullTaskTest extends BuildFileTest
 {
-    use HgTaskTestSkipper;
+    use HgTaskTestSkip;
 
     public function setUp()
     {

--- a/test/classes/phing/tasks/ext/HgTasks/HgPullTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgPullTaskTest.php
@@ -2,6 +2,8 @@
 
 class HgPullTaskTest extends BuildFileTest
 {
+    use HgTaskTestSkipper;
+
     public function setUp()
     {
         mkdir(PHING_TEST_BASE . '/tmp/hgtest');
@@ -27,6 +29,8 @@ class HgPullTaskTest extends BuildFileTest
 
     public function testWrongRepository()
     {
+        $this->markTestAsSkippedWhenHgNotInstalled();
+
         $this->expectBuildExceptionContaining(
             'wrongRepository',
             'wrong repository',

--- a/test/classes/phing/tasks/ext/HgTasks/HgPushTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgPushTaskTest.php
@@ -2,7 +2,7 @@
 
 class HgPushTaskTest extends BuildFileTest
 {
-    use HgTaskTestSkipper;
+    use HgTaskTestSkip;
 
     public function setUp()
     {

--- a/test/classes/phing/tasks/ext/HgTasks/HgPushTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgPushTaskTest.php
@@ -2,6 +2,8 @@
 
 class HgPushTaskTest extends BuildFileTest
 {
+    use HgTaskTestSkipper;
+
     public function setUp()
     {
         mkdir(PHING_TEST_BASE . '/tmp/hgtest');
@@ -27,6 +29,8 @@ class HgPushTaskTest extends BuildFileTest
 
     public function testWrongRepository()
     {
+        $this->markTestAsSkippedWhenHgNotInstalled();
+
         $this->expectBuildExceptionContaining(
             'wrongRepository',
             'wrong repository',

--- a/test/classes/phing/tasks/ext/HgTasks/HgRevertTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgRevertTaskTest.php
@@ -2,7 +2,7 @@
 
 class HgRevertTaskTest extends BuildFileTest
 {
-    use HgTaskTestSkipper;
+    use HgTaskTestSkip;
 
     public function setUp()
     {

--- a/test/classes/phing/tasks/ext/HgTasks/HgRevertTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgRevertTaskTest.php
@@ -2,8 +2,12 @@
 
 class HgRevertTaskTest extends BuildFileTest
 {
+    use HgTaskTestSkipper;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenHgNotInstalled();
+
         mkdir(PHING_TEST_BASE . '/tmp/hgtest');
         $this->configureProject(
             PHING_TEST_BASE

--- a/test/classes/phing/tasks/ext/HgTasks/HgTagTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgTagTaskTest.php
@@ -2,6 +2,8 @@
 
 class HgTagTaskTest extends BuildFileTest
 {
+    use HgTaskTestSkipper;
+
     public function setUp()
     {
         mkdir(PHING_TEST_BASE . '/tmp/hgtest');
@@ -39,6 +41,8 @@ class HgTagTaskTest extends BuildFileTest
 
     public function testRevision()
     {
+        $this->markTestAsSkippedWhenHgNotInstalled();
+
         $this->expectBuildExceptionContaining(
             "testRevision",
             "testRevision",

--- a/test/classes/phing/tasks/ext/HgTasks/HgTagTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgTagTaskTest.php
@@ -2,7 +2,7 @@
 
 class HgTagTaskTest extends BuildFileTest
 {
-    use HgTaskTestSkipper;
+    use HgTaskTestSkip;
 
     public function setUp()
     {

--- a/test/classes/phing/tasks/ext/HgTasks/HgTaskTestSkip.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgTaskTestSkip.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-trait HgTaskTestSkipper
+trait HgTaskTestSkip
 {
 
     public function markTestAsSkippedWhenHgNotInstalled(): void

--- a/test/classes/phing/tasks/ext/HgTasks/HgTaskTestSkip.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgTaskTestSkip.php
@@ -7,7 +7,7 @@ trait HgTaskTestSkip
 
     public function markTestAsSkippedWhenHgNotInstalled(): void
     {
-        exec('hg help', $output, $code);
+        exec('hg help > /dev/null 2>&1', $output, $code);
         if ($code != 0)  {
             $this->markTestSkipped('This test require hg to be installed');
         }

--- a/test/classes/phing/tasks/ext/HgTasks/HgTaskTestSkipper.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgTaskTestSkipper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+trait HgTaskTestSkipper
+{
+
+    public function markTestAsSkippedWhenHgNotInstalled(): void
+    {
+        exec('hg help', $output, $code);
+        if ($code != 0)  {
+            $this->markTestSkipped('This test require hg to be installed');
+        }
+    }
+}

--- a/test/classes/phing/tasks/ext/HgTasks/HgUpdateTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgUpdateTaskTest.php
@@ -2,6 +2,8 @@
 
 class HgUpdateTaskTest extends BuildFileTest
 {
+    use HgTaskTestSkipper;
+
     public function setUp()
     {
         mkdir(PHING_TEST_BASE . '/tmp/hgtest');
@@ -27,6 +29,8 @@ class HgUpdateTaskTest extends BuildFileTest
 
     public function testWrongRepository()
     {
+        $this->markTestAsSkippedWhenHgNotInstalled();
+
         $this->expectBuildExceptionContaining(
             'wrongRepository',
             'wrong repository',

--- a/test/classes/phing/tasks/ext/HgTasks/HgUpdateTaskTest.php
+++ b/test/classes/phing/tasks/ext/HgTasks/HgUpdateTaskTest.php
@@ -2,7 +2,7 @@
 
 class HgUpdateTaskTest extends BuildFileTest
 {
-    use HgTaskTestSkipper;
+    use HgTaskTestSkip;
 
     public function setUp()
     {

--- a/test/classes/phing/tasks/ext/PharDataTaskTest.php
+++ b/test/classes/phing/tasks/ext/PharDataTaskTest.php
@@ -28,6 +28,10 @@ class PharDataTaskTest extends BuildFileTest
 {
     public function setUp()
     {
+        if (!extension_loaded('phar')) {
+                $this->markTestSkipped("PharDataTask require either PHP 5.3 or better or the PECL's Phar extension");
+        }
+
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped("PHAR tests do not run on HHVM");
         }
@@ -58,6 +62,8 @@ class PharDataTaskTest extends BuildFileTest
 
     public function testGenerateTarGz()
     {
+        $this->skipIfCompressionNotSupported(Phar::GZ);
+
         $this->executeTarget(__FUNCTION__);
         $manifestFile = realpath(PHING_TEST_BASE . "/etc/tasks/ext/tmp/phar/archive.tar.gz");
         $this->assertNotFalse($manifestFile);
@@ -65,6 +71,8 @@ class PharDataTaskTest extends BuildFileTest
 
     public function testGenerateTarBz2()
     {
+        $this->skipIfCompressionNotSupported(Phar::BZ2);
+
         $this->executeTarget(__FUNCTION__);
         $manifestFile = realpath(PHING_TEST_BASE . "/etc/tasks/ext/tmp/phar/archive.tar.bz2");
         $this->assertNotFalse($manifestFile);
@@ -79,6 +87,8 @@ class PharDataTaskTest extends BuildFileTest
 
     public function testGenerateZipGz()
     {
+        $this->skipIfCompressionNotSupported(Phar::GZ);
+
         $this->executeTarget(__FUNCTION__);
         $manifestFile = realpath(PHING_TEST_BASE . "/etc/tasks/ext/tmp/phar/archive.zip");
         $this->assertNotFalse($manifestFile);
@@ -86,8 +96,17 @@ class PharDataTaskTest extends BuildFileTest
 
     public function testGenerateZipBz2()
     {
+        $this->skipIfCompressionNotSupported(Phar::BZ2);
+
         $this->executeTarget(__FUNCTION__);
         $manifestFile = realpath(PHING_TEST_BASE . "/etc/tasks/ext/tmp/phar/archive.zip");
         $this->assertNotFalse($manifestFile);
+    }
+
+    private function skipIfCompressionNotSupported(int $compression): void
+    {
+        if (!Phar::canCompress($compression)) {
+            $this->markTestSkipped('This test require Phar to support ' . $compression . ' compression');
+        }
     }
 }

--- a/test/classes/phing/tasks/ext/PharPackageTaskTest.php
+++ b/test/classes/phing/tasks/ext/PharPackageTaskTest.php
@@ -29,6 +29,10 @@ class PharPackageTaskTest extends BuildFileTest
 {
     public function setUp()
     {
+        if (ini_get('phar.readonly') == "1") {
+            $this->markTestSkipped("This test require phar.readonly php.ini setting to be disabled");
+        }
+
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped("PHAR tests do not run on HHVM");
         }

--- a/test/classes/phing/tasks/ext/ZipUnzipTaskTest.php
+++ b/test/classes/phing/tasks/ext/ZipUnzipTaskTest.php
@@ -28,6 +28,9 @@ class ZipUnzipTaskTest extends BuildFileTest
 {
     public function setUp()
     {
+        if (!extension_loaded('zip')) {
+            $this->markTestSkipped("Zip extension is required");
+        }
         $this->configureProject(
             PHING_TEST_BASE
             . "/etc/tasks/ext/ZipUnzipTaskTest.xml"

--- a/test/classes/phing/tasks/ext/svn/SvnCheckoutTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnCheckoutTaskTest.php
@@ -24,8 +24,11 @@
  */
 class SvnCheckoutTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnCheckoutTest.xml');
     }
 

--- a/test/classes/phing/tasks/ext/svn/SvnExportTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnExportTaskTest.php
@@ -24,8 +24,11 @@
  */
 class SvnExportTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnExportTest.xml', false);
     }
 

--- a/test/classes/phing/tasks/ext/svn/SvnInfoTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnInfoTaskTest.php
@@ -24,8 +24,11 @@
  */
 class SvnInfoTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnInfoTest.xml');
     }
 

--- a/test/classes/phing/tasks/ext/svn/SvnLastRevisionTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnLastRevisionTaskTest.php
@@ -24,8 +24,11 @@
  */
 class SvnLastRevisionTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnLastRevisionTest.xml');
         $this->rmdir(PHING_TEST_BASE . '/tmp/svn');
     }

--- a/test/classes/phing/tasks/ext/svn/SvnListTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnListTaskTest.php
@@ -24,8 +24,11 @@
  */
 class SvnListTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnListTest.xml');
         $this->rmdir(PHING_TEST_BASE . '/tmp/svn');
     }

--- a/test/classes/phing/tasks/ext/svn/SvnLogTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnLogTaskTest.php
@@ -24,8 +24,11 @@
  */
 class SvnLogTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnLogTest.xml');
     }
 

--- a/test/classes/phing/tasks/ext/svn/SvnPropTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnPropTaskTest.php
@@ -23,8 +23,11 @@
  */
 class SvnPropTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnPropTest.xml');
     }
 

--- a/test/classes/phing/tasks/ext/svn/SvnSwitchTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnSwitchTaskTest.php
@@ -24,8 +24,12 @@
  */
 class SvnSwitchTaskTest extends BuildFileTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
+
         if (is_readable(PHING_TEST_BASE . '/tmp/svn')) {
             // make sure we purge previously created directory
             // if left-overs from previous run are found

--- a/test/classes/phing/tasks/ext/svn/SvnTaskTestSkip.php
+++ b/test/classes/phing/tasks/ext/svn/SvnTaskTestSkip.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+trait SvnTaskTestSkip
+{
+
+    public function markTestAsSkippedWhenSvnNotInstalled(): void
+    {
+        exec('svn help > /dev/null 2>&1', $output, $code);
+        if ($code != 0)  {
+            $this->markTestSkipped('This test require svn to be installed');
+        }
+    }
+}

--- a/test/classes/phing/tasks/ext/svn/SvnUpdateTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnUpdateTaskTest.php
@@ -24,8 +24,11 @@
  */
 class SvnUpdateTaskTest extends AbstractSvnTaskTest
 {
+    use SvnTaskTestSkip;
+
     public function setUp()
     {
+        $this->markTestAsSkippedWhenSvnNotInstalled();
         $this->initialize('SvnUpdateTest.xml', false);
     }
 

--- a/test/classes/phing/types/PearPackageFileSetBuildTest.php
+++ b/test/classes/phing/types/PearPackageFileSetBuildTest.php
@@ -32,6 +32,10 @@ class PearPackageFileSetBuildTest extends BuildFileTest
 {
     public function setUp()
     {
+        if (!class_exists('PEAR_Config')) {
+            $this->markTestSkipped("This test requires PEAR to be installed");
+        }
+
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped("PEAR tests do not run on HHVM");
         }

--- a/test/classes/phing/types/PearPackageFileSetTest.php
+++ b/test/classes/phing/types/PearPackageFileSetTest.php
@@ -31,6 +31,10 @@ class PearPackageFileSetTest extends BuildFileTest
 {
     public function setUp()
     {
+        if (!class_exists('PEAR_Config')) {
+            $this->markTestSkipped("This test requires PEAR to be installed");
+        }
+
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped("PEAR tests do not run on HHVM");
         }

--- a/test/classes/phing/util/PearPackageScannerTest.php
+++ b/test/classes/phing/util/PearPackageScannerTest.php
@@ -33,6 +33,10 @@ class PearPackageScannerTest extends BuildFileTest
 
     public function setUp()
     {
+        if (!class_exists('PEAR_Config')) {
+            $this->markTestSkipped("This test requires PEAR to be installed");
+        }
+
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped("PEAR tests do not run on HHVM");
         }

--- a/test/classes/phing/util/PearPackageScannerTest.php
+++ b/test/classes/phing/util/PearPackageScannerTest.php
@@ -97,7 +97,7 @@ class PearPackageScannerTest extends BuildFileTest
         foreach ($arFiles as $file) {
             $fullpath = $basedir . $file;
             $this->assertTrue(
-                file_exists($fullpath),
+                file_exists($fullpath) || file_exists($fullpath . '.gz'),
                 'File does not exist: ' . $file . ' at ' . $fullpath
             );
         }


### PR DESCRIPTION
This PR adds skips to tests that depends on external utilities when that utilities are absent/disabled. Thanks to this, tester does not have to install unnecessary utilities.