### PR TITLE
fixed typos in error messages

### DIFF
--- a/classes/phing/filters/LineContains.php
+++ b/classes/phing/filters/LineContains.php
@@ -151,7 +151,7 @@ class LineContains extends BaseParamFilterReader implements ChainableReader
     {
         // type check, error must never occur, bad code of it does
         if (!is_array($contains)) {
-            throw new Exception("Excpected array got something else");
+            throw new Exception("Expected array got something else");
         }
 
         $this->_contains = $contains;

--- a/classes/phing/filters/LineContainsRegexp.php
+++ b/classes/phing/filters/LineContainsRegexp.php
@@ -171,7 +171,7 @@ class LineContainsRegexp extends BaseParamFilterReader implements ChainableReade
     {
         // type check, error must never occur, bad code of it does
         if (!is_array($regexps)) {
-            throw new Exception("Excpected an 'array', got something else");
+            throw new Exception("Expected an 'array', got something else");
         }
         $this->_regexps = $regexps;
     }

--- a/classes/phing/filters/ReplaceTokens.php
+++ b/classes/phing/filters/ReplaceTokens.php
@@ -246,7 +246,7 @@ class ReplaceTokens extends BaseParamFilterReader implements ChainableReader
     {
         // type check, error must never occur, bad code of it does
         if (!is_array($tokens)) {
-            throw new Exception("Excpected 'array', got something else");
+            throw new Exception("Expected 'array', got something else");
         }
 
         $this->_tokens = $tokens;

--- a/classes/phing/filters/StripLineComments.php
+++ b/classes/phing/filters/StripLineComments.php
@@ -128,7 +128,7 @@ class StripLineComments extends BaseParamFilterReader implements ChainableReader
     public function setComments($lineBreaks)
     {
         if (!is_array($lineBreaks)) {
-            throw new Exception("Excpected 'array', got something else");
+            throw new Exception("Expected 'array', got something else");
         }
         $this->_comments = $lineBreaks;
     }


### PR DESCRIPTION
Fixed some typos in error messages. Should be `Expected` instead of `Excpected`.