### PR TITLE
Fix PHP CodeSniffer cache write to directory

### DIFF
--- a/classes/phing/tasks/ext/PhpCodeSnifferTask.php
+++ b/classes/phing/tasks/ext/PhpCodeSnifferTask.php
@@ -527,7 +527,7 @@ class PhpCodeSnifferTask extends Task
             require_once 'phing/tasks/ext/phpcs/Reports_PhingRemoveFromCache.php';
             PHP_CodeSniffer_Reports_PhingRemoveFromCache::setCache($this->cache);
             // add a fake report to remove from cache
-            $_SERVER['argv'][] = '--report-phingRemoveFromCache=';
+            $_SERVER['argv'][] = '--report-phingRemoveFromCache';
             $_SERVER['argc']++;
         }
 


### PR DESCRIPTION
Fix error of PHP_CodeSniffer_Reports_PhingRemoveFromCache try to write to content to directory path :
[PHP Error] file_put_contents(/data/): failed to open stream: Is a directory [line 191 of /data/library/vendor/squizlabs/php_codesniffer/CodeSniffer/Reporting.php]