### PR TITLE
Fixed isBoolean check.

### DIFF
--- a/classes/phing/util/StringHelper.php
+++ b/classes/phing/util/StringHelper.php
@@ -91,7 +91,7 @@ class StringHelper
 
         $test = strtolower(trim($s));
 
-        return (boolean) in_array($test, array_merge(self::$FALSE_VALUES, self::$TRUE_VALUES));
+        return in_array($test, array_merge(self::$FALSE_VALUES, self::$TRUE_VALUES), true);
     }
 
     /**


### PR DESCRIPTION
Values like `'0000'` are taken as boolean, which is not the desired result.