### PR TITLE
Consistent usage of to string

### DIFF
--- a/classes/phing/BuildException.php
+++ b/classes/phing/BuildException.php
@@ -121,6 +121,6 @@ class BuildException extends RuntimeException
     public function setLocation(Location $loc)
     {
         $this->location = $loc;
-        $this->message = $loc->toString() . ': ' . $this->message;
+        $this->message = (string) $loc . ': ' . $this->message;
     }
 }

--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -183,20 +183,18 @@ class Phing
                 $exitCode = 0;
             } catch (ExitStatusException $ese) {
                 $exitCode = $ese->getCode();
-                if ($exitCode != 0) {
+                if ($exitCode !== 0) {
                     self::handleLogfile();
                     throw $ese;
                 }
             }
         } catch (BuildException $exc) {
             // avoid printing output twice: self::printMessage($exc);
-        } catch (Exception $exc) {
-            echo $exc->getTraceAsString();
+        } catch (Throwable $exc) {
             self::printMessage($exc);
+        } finally {
+            self::handleLogfile();
         }
-
-        // everything fine, shutdown
-        self::handleLogfile();
         self::statusExit($exitCode);
     }
 
@@ -221,7 +219,7 @@ class Phing
             self::initializeOutputStreams();
         }
         if (self::getMsgOutputLevel() >= Project::MSG_VERBOSE) {
-            self::$err->write($t->__toString() . PHP_EOL);
+            self::$err->write((string) $t . PHP_EOL);
         } else {
             self::$err->write($t->getMessage() . PHP_EOL);
         }

--- a/classes/phing/Project.php
+++ b/classes/phing/Project.php
@@ -795,7 +795,7 @@ class Project
 
         $retHuman = "";
         for ($i = 0, $_i = count($ret); $i < $_i; $i++) {
-            $retHuman .= $ret[$i]->toString() . " ";
+            $retHuman .= (string) $ret[$i] . " ";
         }
         $this->log("Build sequence for target '$rootTarget' is: $retHuman", Project::MSG_VERBOSE);
 
@@ -817,7 +817,7 @@ class Project
 
         $retHuman = "";
         for ($i = 0, $_i = count($ret); $i < $_i; $i++) {
-            $retHuman .= $ret[$i]->toString() . " ";
+            $retHuman .= (string) $ret[$i] . " ";
         }
         $this->log("Complete build sequence is: $retHuman", Project::MSG_VERBOSE);
 
@@ -1083,7 +1083,7 @@ class Project
      * @param $message
      * @param $priority
      */
-    public function fireMessageLoggedEvent($event, $message, $priority)
+    public function fireMessageLoggedEvent(BuildEvent $event, $message, $priority)
     {
         $event->setMessage($message, $priority);
         foreach ($this->listeners as $listener) {

--- a/classes/phing/Target.php
+++ b/classes/phing/Target.php
@@ -314,17 +314,6 @@ class Target implements TaskContainer
      *
      * @return string The string representation of this target
      */
-    public function toString()
-    {
-        return (string) $this;
-    }
-
-    /**
-     * Returns a string representation of this target. In our case it
-     * simply returns the target name field
-     *
-     * @return string The string representation of this target
-     */
     public function __toString()
     {
         return (string) $this->name;

--- a/classes/phing/dispatch/DispatchUtils.php
+++ b/classes/phing/dispatch/DispatchUtils.php
@@ -58,11 +58,7 @@ class DispatchUtils
                     $c = new ReflectionClass($dispatchable);
                     $actionM = $c->getMethod($mName);
                     $o = $actionM->invoke($dispatchable);
-                    if (method_exists($o, 'toString')) {
-                        $methodName = trim($o->toString());
-                    } else {
-                        $methodName = trim((string) $o);
-                    }
+                    $methodName = trim((string) $o);
                     if (empty($methodName)) {
                         throw new ReflectionException();
                     }

--- a/classes/phing/listener/XmlLogger.php
+++ b/classes/phing/listener/XmlLogger.php
@@ -241,7 +241,7 @@ class XmlLogger implements BuildLogger
 
         $taskElement = $this->doc->createElement(XmlLogger::TASK_TAG);
         $taskElement->setAttribute(XmlLogger::NAME_ATTR, $task->getTaskName());
-        $taskElement->setAttribute(XmlLogger::LOCATION_ATTR, $task->getLocation()->toString());
+        $taskElement->setAttribute(XmlLogger::LOCATION_ATTR, (string) $task->getLocation());
 
         $this->timesStack[] = Phing::currentTimeMillis();
         $this->elementStack[] = $taskElement;

--- a/classes/phing/parser/Location.php
+++ b/classes/phing/parser/Location.php
@@ -83,7 +83,7 @@ class Location
      *
      * @return string the string representation of this Location object
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         if ($this->fileName !== null) {
@@ -95,13 +95,5 @@ class Location
         }
 
         return (string) $buf;
-    }
-
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->toString();
     }
 }

--- a/classes/phing/system/io/PhingFile.php
+++ b/classes/phing/system/io/PhingFile.php
@@ -1101,16 +1101,6 @@ class PhingFile
     }
 
     /**
-     * Backwards compatibility - @see __toString()
-     *
-     * @return string
-     */
-    public function toString()
-    {
-        return $this->__toString();
-    }
-
-    /**
      * Return string representation of the object
      *
      * @return string

--- a/classes/phing/system/lang/EventObject.php
+++ b/classes/phing/system/lang/EventObject.php
@@ -46,7 +46,7 @@ class EventObject
     }
 
     /** Returns a String representation of this EventObject.*/
-    public function toString()
+    public function __toString()
     {
         if (method_exists($this->source, "toString")) {
             return get_class($this) . "[source=" . $this->source->toString() . "]";

--- a/classes/phing/system/util/Properties.php
+++ b/classes/phing/system/util/Properties.php
@@ -111,7 +111,7 @@ class Properties
      *
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         foreach ($this->properties as $key => $item) {
@@ -147,7 +147,7 @@ class Properties
             if ($header !== null) {
                 $fw->write("# " . $header . PHP_EOL);
             }
-            $fw->write($this->toString());
+            $fw->write((string) $this);
             $fw->close();
         } catch (IOException $e) {
             throw new IOException("Error writing property file: " . $e->getMessage());

--- a/classes/phing/tasks/ext/property/PathToFileSet.php
+++ b/classes/phing/tasks/ext/property/PathToFileSet.php
@@ -104,7 +104,7 @@ class PathToFileSet extends Task
         }
         if (!$this->dir->isDirectory()) {
             throw new BuildException(
-                $this->dir->toString() . " is not a directory");
+                (string) $this->dir . " is not a directory");
         }
         $path = $this->getProject()->getReference($this->pathRefId);
         if ($path == null) {

--- a/classes/phing/tasks/system/MatchingTask.php
+++ b/classes/phing/tasks/system/MatchingTask.php
@@ -217,9 +217,9 @@ abstract class MatchingTask extends Task implements SelectorContainer
      *
      * @return int The number of selectors in this container
      */
-    public function selectorCount()
+    public function count()
     {
-        return $this->fileset->selectorCount();
+        return $this->fileset->count();
     }
 
     /**

--- a/classes/phing/tasks/system/PropertyTask.php
+++ b/classes/phing/tasks/system/PropertyTask.php
@@ -255,7 +255,7 @@ class PropertyTask extends Task
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         return (string) $this->value;
     }
@@ -351,8 +351,6 @@ class PropertyTask extends Task
 
                 if ($referencedObject instanceof Exception) {
                     $reference = $referencedObject->getMessage();
-                } elseif (method_exists($referencedObject, 'toString')) {
-                    $reference = $referencedObject->toString();
                 } else {
                     $reference = (string) $referencedObject;
                 }
@@ -364,8 +362,6 @@ class PropertyTask extends Task
 
                     if ($referencedObject instanceof Exception) {
                         $reference = $referencedObject->getMessage();
-                    } elseif (method_exists($referencedObject, 'toString')) {
-                        $reference = $referencedObject->toString();
                     } else {
                         $reference = (string) $referencedObject;
                     }

--- a/classes/phing/tasks/system/TempFile.php
+++ b/classes/phing/tasks/system/TempFile.php
@@ -173,6 +173,6 @@ class TempFile extends Task
             $this->deleteOnExit,
             $this->createFile
         );
-        $this->getProject()->setNewProperty($this->property, $tmpFile->toString());
+        $this->getProject()->setNewProperty($this->property, (string) $tmpFile);
     }
 }

--- a/classes/phing/tasks/system/condition/IsFileSelected.php
+++ b/classes/phing/tasks/system/condition/IsFileSelected.php
@@ -51,7 +51,7 @@ class IsFileSelected extends AbstractSelectorContainer implements Condition
      */
     public function validate()
     {
-        if ($this->selectorCount() != 1) {
+        if ($this->count() != 1) {
             throw new BuildException("Only one selector allowed");
         }
         parent::validate();

--- a/classes/phing/types/DataType.php
+++ b/classes/phing/types/DataType.php
@@ -37,7 +37,7 @@ class DataType extends ProjectComponent
      *
      * @var Reference $ref
      */
-    public $ref = null;
+    private $ref;
 
     /**
      * Are we sure we don't hold circular references?

--- a/classes/phing/types/ExcludesNameEntry.php
+++ b/classes/phing/types/ExcludesNameEntry.php
@@ -72,7 +72,7 @@ class ExcludesNameEntry
      *
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         return $this->name;
     }

--- a/classes/phing/types/PatternSet.php
+++ b/classes/phing/types/PatternSet.php
@@ -413,7 +413,7 @@ class PatternSet extends DataType
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
 
         // We can't compile includeList into array because, toString() does
@@ -427,7 +427,7 @@ class PatternSet extends DataType
         } else {
             $includes = "";
             foreach ($this->includeList as $ne) {
-                $includes .= $ne->toString() . ",";
+                $includes .= (string) $ne . ",";
             }
             $includes = rtrim($includes, ",");
         }
@@ -437,7 +437,7 @@ class PatternSet extends DataType
         } else {
             $excludes = "";
             foreach ($this->excludeList as $ne) {
-                $excludes .= $ne->toString() . ",";
+                $excludes .= (string) $ne . ",";
             }
             $excludes = rtrim($excludes, ",");
         }

--- a/classes/phing/types/PatternSetNameEntry.php
+++ b/classes/phing/types/PatternSetNameEntry.php
@@ -105,7 +105,7 @@ class PatternSetNameEntry
      * Gets a string representation of this pattern.
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = $this->name;
         if (($this->ifCond !== null) || ($this->unlessCond !== null)) {

--- a/classes/phing/types/PropertyValue.php
+++ b/classes/phing/types/PropertyValue.php
@@ -59,7 +59,7 @@ class PropertyValue
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         return $this->getValue();
     }

--- a/classes/phing/types/selectors/AbstractSelectorContainer.php
+++ b/classes/phing/types/selectors/AbstractSelectorContainer.php
@@ -106,11 +106,11 @@ abstract class AbstractSelectorContainer extends DataType implements SelectorCon
      * @throws Exception
      * @return int The number of selectors in this container
      */
-    public function selectorCount()
+    public function count()
     {
         if ($this->isReference() && $this->getProject() !== null) {
             try {
-                return $this->getRef($this->getProject())->selectorCount();
+                return $this->getRef($this->getProject())->count();
             } catch (Exception $e) {
                 throw $e;
             }

--- a/classes/phing/types/selectors/AndSelector.php
+++ b/classes/phing/types/selectors/AndSelector.php
@@ -32,12 +32,12 @@ class AndSelector extends BaseSelectorContainer
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         if ($this->hasSelectors()) {
             $buf .= "{andselect: ";
-            $buf .= parent::toString();
+            $buf .= parent::__toString();
             $buf .= "}";
         }
 

--- a/classes/phing/types/selectors/BaseSelectorContainer.php
+++ b/classes/phing/types/selectors/BaseSelectorContainer.php
@@ -23,7 +23,7 @@
  * @author <a href="mailto:bruce@callenish.com">Bruce Atherton</a> (Ant)
  * @package phing.types.selectors
  */
-abstract class BaseSelectorContainer extends BaseSelector implements SelectorContainer
+abstract class BaseSelectorContainer extends BaseSelector implements SelectorContainer, Countable
 {
     use SelectorAware;
 
@@ -34,12 +34,12 @@ abstract class BaseSelectorContainer extends BaseSelector implements SelectorCon
      *
      * @return string comma separated list of Selectors contained in this one
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         $arr = $this->selectorElements();
         for ($i = 0, $size = count($arr); $i < $size; $i++) {
-            $buf .= $arr[$i]->toString() . (isset($arr[$i + 1]) ? ', ' : '');
+            $buf .= (string) $arr[$i] . (isset($arr[$i + 1]) ? ', ' : '');
         }
 
         return $buf;

--- a/classes/phing/types/selectors/ContainsRegexpSelector.php
+++ b/classes/phing/types/selectors/ContainsRegexpSelector.php
@@ -54,7 +54,7 @@ class ContainsRegexpSelector extends BaseExtendSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{containsregexpselector expression: ";
         $buf .= $this->userProvidedExpression;

--- a/classes/phing/types/selectors/ContainsSelector.php
+++ b/classes/phing/types/selectors/ContainsSelector.php
@@ -41,7 +41,7 @@ class ContainsSelector extends BaseExtendSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{containsselector text: ";
         $buf .= $this->contains;

--- a/classes/phing/types/selectors/DateSelector.php
+++ b/classes/phing/types/selectors/DateSelector.php
@@ -55,7 +55,7 @@ class DateSelector extends BaseExtendSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{dateselector date: ";
         $buf .= $this->dateTime;

--- a/classes/phing/types/selectors/DependSelector.php
+++ b/classes/phing/types/selectors/DependSelector.php
@@ -38,7 +38,7 @@ class DependSelector extends BaseSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{dependselector targetdir: ";
         if ($this->targetdir === null) {
@@ -50,10 +50,10 @@ class DependSelector extends BaseSelector
         $buf .= $this->granularity;
         if ($this->map !== null) {
             $buf .= " mapper: ";
-            $buf .= $this->map->toString();
+            $buf .= (string) $this->map;
         } elseif ($this->mapperElement !== null) {
             $buf .= " mapper: ";
-            $buf .= $this->mapperElement->toString();
+            $buf .= (string) $this->mapperElement;
         }
         $buf .= "}";
 

--- a/classes/phing/types/selectors/DepthSelector.php
+++ b/classes/phing/types/selectors/DepthSelector.php
@@ -40,7 +40,7 @@ class DepthSelector extends BaseExtendSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{depthselector min: ";
         $buf .= $this->min;

--- a/classes/phing/types/selectors/FilenameSelector.php
+++ b/classes/phing/types/selectors/FilenameSelector.php
@@ -44,7 +44,7 @@ class FilenameSelector extends BaseExtendSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{filenameselector name: ";
         if ($this->pattern !== null) {

--- a/classes/phing/types/selectors/MajoritySelector.php
+++ b/classes/phing/types/selectors/MajoritySelector.php
@@ -39,12 +39,12 @@ class MajoritySelector extends BaseSelectorContainer
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         if ($this->hasSelectors()) {
             $buf .= "{majorityselect: ";
-            $buf .= parent::toString();
+            $buf .= parent::__toString();
             $buf .= "}";
         }
 

--- a/classes/phing/types/selectors/NoneSelector.php
+++ b/classes/phing/types/selectors/NoneSelector.php
@@ -33,12 +33,12 @@ class NoneSelector extends BaseSelectorContainer
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         if ($this->hasSelectors()) {
             $buf .= "{noneselect: ";
-            $buf .= parent::toString();
+            $buf .= parent::__toString();
             $buf .= "}";
         }
 

--- a/classes/phing/types/selectors/NotSelector.php
+++ b/classes/phing/types/selectors/NotSelector.php
@@ -34,12 +34,12 @@ class NotSelector extends NoneSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         if ($this->hasSelectors()) {
             $buf .= "{notselect: ";
-            $buf .= parent::toString();
+            $buf .= parent::__toString();
             $buf .= "}";
         }
 
@@ -52,7 +52,7 @@ class NotSelector extends NoneSelector
      */
     public function verifySettings()
     {
-        if ($this->selectorCount() != 1) {
+        if ($this->count() !== 1) {
             $this->setError(
                 "One and only one selector is allowed within the " .
                 "<not> tag"

--- a/classes/phing/types/selectors/OrSelector.php
+++ b/classes/phing/types/selectors/OrSelector.php
@@ -32,12 +32,12 @@ class OrSelector extends BaseSelectorContainer
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "";
         if ($this->hasSelectors()) {
             $buf .= "{orselect: ";
-            $buf .= parent::toString();
+            $buf .= parent::__toString();
             $buf .= "}";
         }
 

--- a/classes/phing/types/selectors/PresentSelector.php
+++ b/classes/phing/types/selectors/PresentSelector.php
@@ -39,7 +39,7 @@ class PresentSelector extends BaseSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{presentselector targetdir: ";
         if ($this->targetdir === null) {
@@ -54,9 +54,9 @@ class PresentSelector extends BaseSelector
             $buf .= "srconly";
         }
         if ($this->map !== null) {
-            $buf .= $this->map->toString();
+            $buf .= (string) $this->map;
         } elseif ($this->mapperElement !== null) {
-            $buf .= $this->mapperElement->toString();
+            $buf .= (string) $this->mapperElement;
         }
         $buf .= "}";
 

--- a/classes/phing/types/selectors/SelectSelector.php
+++ b/classes/phing/types/selectors/SelectSelector.php
@@ -36,16 +36,9 @@ class SelectSelector extends AndSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
-        $buf = "";
-        if ($this->hasSelectors()) {
-            $buf .= "{select: ";
-            $buf .= parent::toString();
-            $buf .= "}";
-        }
-
-        return $buf;
+        return $this->hasSelectors() ? sprintf('{select: %s}', parent::__toString()) : '';
     }
 
     /**
@@ -54,9 +47,7 @@ class SelectSelector extends AndSelector
      */
     private function getRef()
     {
-        $o = $this->getCheckedRef(get_class($this), "SelectSelector");
-
-        return $o;
+        return $this->getCheckedRef(get_class($this), "SelectSelector");
     }
 
     /**
@@ -64,23 +55,19 @@ class SelectSelector extends AndSelector
      */
     public function hasSelectors()
     {
-        if ($this->isReference()) {
-            return $this->getRef()->hasSelectors();
-        }
-
-        return parent::hasSelectors();
+        return $this->isReference() ? $this->getRef()->hasSelectors() : parent::hasSelectors();
     }
 
     /**
      * Gives the count of the number of selectors in this container
      */
-    public function selectorCount()
+    public function count()
     {
         if ($this->isReference()) {
-            return $this->getRef()->selectorCount();
+            return count($this->getRef());
         }
 
-        return parent::selectorCount();
+        return parent::count();
     }
 
     /**
@@ -90,11 +77,7 @@ class SelectSelector extends AndSelector
      */
     public function getSelectors(Project $p)
     {
-        if ($this->isReference()) {
-            return $this->getRef()->getSelectors($p);
-        }
-
-        return parent::getSelectors($p);
+        return $this->isReference() ? $this->getRef()->getSelectors($p) : parent::getSelectors($p);
     }
 
     /**
@@ -102,11 +85,7 @@ class SelectSelector extends AndSelector
      */
     public function selectorElements()
     {
-        if ($this->isReference()) {
-            return $this->getRef()->selectorElements();
-        }
-
-        return parent::selectorElements();
+        return $this->isReference() ? $this->getRef()->selectorElements() : parent::selectorElements();
     }
 
     /**
@@ -130,7 +109,7 @@ class SelectSelector extends AndSelector
      */
     public function verifySettings()
     {
-        if ($this->selectorCount() != 1) {
+        if ($this->count() != 1) {
             $this->setError(
                 "One and only one selector is allowed within the "
                 . "<selector> tag"

--- a/classes/phing/types/selectors/SelectorAware.php
+++ b/classes/phing/types/selectors/SelectorAware.php
@@ -35,7 +35,7 @@ trait SelectorAware
     /**
      * Gives the count of the number of selectors in this container
      */
-    public function selectorCount()
+    public function count()
     {
         return count($this->selectorsList);
     }

--- a/classes/phing/types/selectors/SelectorContainer.php
+++ b/classes/phing/types/selectors/SelectorContainer.php
@@ -38,7 +38,7 @@ interface SelectorContainer
      *
      * @return int the number of selectors in this container
      */
-    public function selectorCount();
+    public function count();
 
     /**
      * Returns a *copy* of the set of selectors as an array.

--- a/classes/phing/types/selectors/SizeSelector.php
+++ b/classes/phing/types/selectors/SizeSelector.php
@@ -90,7 +90,7 @@ class SizeSelector extends BaseExtendSelector
     /**
      * @return string
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{sizeselector value: ";
         $buf .= $this->sizelimit;

--- a/classes/phing/types/selectors/TypeSelector.php
+++ b/classes/phing/types/selectors/TypeSelector.php
@@ -38,7 +38,7 @@ class TypeSelector extends BaseExtendSelector
     /**
      * @return string A string describing this object
      */
-    public function toString()
+    public function __toString()
     {
         $buf = "{typeselector type: " . $this->type . "}";
 

--- a/test/classes/phing/system/util/PropertiesTest.php
+++ b/test/classes/phing/system/util/PropertiesTest.php
@@ -73,7 +73,7 @@ class PropertiesTest extends \PHPUnit\Framework\TestCase
     {
         $this->props->put('a', 'b');
 
-        $this->assertEquals("a=b" . PHP_EOL, $this->props->toString());
+        $this->assertEquals("a=b" . PHP_EOL, (string) $this->props);
     }
 
     public function testStore()

--- a/test/classes/phing/tasks/system/DependSetTest.php
+++ b/test/classes/phing/tasks/system/DependSetTest.php
@@ -46,7 +46,7 @@ class DependSetTest extends BuildFileTest
         $this->executeTarget(__FUNCTION__);
         $f = new PhingFile($this->getProjectDir(), 'older.tmp');
         if ($f->exists()) {
-            $this->fail('dependset failed to remove out of date file ' . $f->toString());
+            $this->fail('dependset failed to remove out of date file ' . (string) $f);
         }
     }
 }


### PR DESCRIPTION
* Consistent usage of __toString
* Selector usage is now logged in debug mode:
```
  +Task: pathconvert
Property ${line.separator} => 

    -calling setter PathConvert::setPathSep()
    -calling setter PathConvert::setProperty()
    -calling setter PathConvert::setRefid()
FileSet: Setup file scanner in dir . with patternSet{ includes: abc/**  excludes: empty }
{orselect: {filenameselector name: **\exportspecial\** negate: false casesensitive: true}, {notselect: {noneselect: {filenameselector name: **\*export*\** negate: false casesensitive: true}}}}
```
