### PR TITLE
Added snapshot versions for all sup. php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ language: php
 php:
   - 7.1
   - 7.2
-  - nightly
+  - 7.1snapshot
+  - 7.2snapshot
+  - master
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: nightly
+    - php: 7.1snapshot
+    - php: 7.2snapshot
+    - php: master
 
 cache:
   directories:


### PR DESCRIPTION
Travis supports to use the latest snapshot versions for php versions, so we should use them.