### PR TITLE
Fixed test execution.

### DIFF
--- a/classes/phing/filters/XsltFilter.php
+++ b/classes/phing/filters/XsltFilter.php
@@ -270,9 +270,13 @@ class XsltFilter extends BaseParamFilterReader implements ChainableReader
         $xslDom->resolveExternals = $this->resolveStylesheetExternals;
 
         if ($this->html) {
-            $xmlDom->loadHTML($xml);
+            $result = @$xmlDom->loadHTML($xml);
         } else {
-            $xmlDom->loadXML($xml);
+            $result = @$xmlDom->loadXML($xml);
+        }
+        
+        if ($result === false) {
+            throw new BuildException('Invalid syntax detected.');
         }
 
         $xslDom->loadXML($xsl);


### PR DESCRIPTION
Fixed the XsltFilter to react correctly on failure.
This solves the test execution, but shows us another failure.
see https://travis-ci.org/phingofficial/phing/jobs/393323312
```
[filehash] Calculating sha1 hash from: /home/travis/build/phingofficial/phing/build/full/phing-3.0.0-alpha2.phar
     [exec] gpg: skipped "mrook@php.net": secret key not available
     [exec] gpg: signing failed: secret key not available
[phingcall] Task exited with code 2
BUILD FAILED
/home/travis/build/phingofficial/phing/build/build.xml:203:26 Execution of the target buildfile failed. Aborting.
```
