### PR TITLE
Expanding a Property Reference with ${toString:}

### DIFF
--- a/docs/guide/en/source/chapters/gettingstarted.xml
+++ b/docs/guide/en/source/chapters/gettingstarted.xml
@@ -322,6 +322,16 @@
                 with the value 'build', then this could be used in an attribute like this:
                     <literal>${BC_BUILD_DIR}/en</literal> . This is resolved to
                     <literal>build/en</literal>.</para>
+            <para>Getting the value of a Reference with <literal>${toString:}</literal>
+                Any Phing type item which has been declared with a reference can also its string value extracted by using
+                the ${toString:} operation, with the name of the reference listed after the toString: text.
+                The __toString() method of the php class instance that is referenced is invoked
+                all built in types strive to produce useful and relevant output in such an instance.</para>
+            <para>For example, here is how to get a listing of the files in a fileset:
+                <programlisting language="xml">&lt;fileset id="sourcefiles" dir="src" includes="**/*.php"/>
+&lt;echo> sourcefiles = ${toString:sourcefiles} &lt;/echo></programlisting>
+            </para>
+            <para>There is no guarantee that external types provide meaningful information in such a situation</para>
 
             <sect3>
                 <title>Built-in Properties</title>

--- a/docs/guide/en/source/master.xml
+++ b/docs/guide/en/source/master.xml
@@ -55,6 +55,13 @@
                 </personname>
                 <email>ken@linux.ie</email>
             </author>
+            <author>
+                <personname>
+                    <firstname>Siad</firstname>
+                    <surname>Ardroumli</surname>
+                </personname>
+                <email>siad.ardroumli@gmail.com</email>
+            </author>
         </authorgroup>
         <pubdate><?dbtimestamp format="Y-m-d"?></pubdate>
         <copyright>

--- a/test/classes/phing/tasks/PropertyTaskTest.php
+++ b/test/classes/phing/tasks/PropertyTaskTest.php
@@ -101,6 +101,11 @@ class PropertyTaskTest extends BuildFileTest
         $this->fail("Did not throw exception on circular exception");
     }
 
+    public function testToString()
+    {
+        $this->expectLog(__FUNCTION__, 'sourcefiles = filehash.bin');
+    }
+
     /**
      * Inspired by @link http://www.phing.info/trac/ticket/1118
      * This test should not throw exceptions

--- a/test/etc/tasks/property.xml
+++ b/test/etc/tasks/property.xml
@@ -53,4 +53,9 @@
   <target name="testUsingPropertyTwiceInPropertyValueShouldNotThrowException">
       <property file="property_notcircular.properties"/>
   </target>
+
+  <target name="testToString">
+    <fileset id="sourcefiles" dir="././ext/" includes="**/*.bin"/>
+    <echo> sourcefiles = ${toString:sourcefiles} </echo>
+  </target>
 </project>


### PR DESCRIPTION
Instead of a property value we would be able to invoke the `__toString` method of a reference like:

```
    <fileset id="sourcefiles" dir="src" includes="**/*.php"/>
    <echo> sourcefiles = ${toString:sourcefiles} </echo>
```
