### PR TITLE
#946: Trim outputProperty value of GitLogTask.

### DIFF
--- a/classes/phing/tasks/ext/git/GitLogTask.php
+++ b/classes/phing/tasks/ext/git/GitLogTask.php
@@ -141,7 +141,7 @@ class GitLogTask extends GitBaseTask
         }
 
         if (null !== $this->outputProperty) {
-            $this->project->setProperty($this->outputProperty, $output);
+            $this->project->setProperty($this->outputProperty, trim($output));
         }
 
         $this->log(

--- a/test/classes/phing/tasks/ext/GitTasks/GitLogTaskTest.php
+++ b/test/classes/phing/tasks/ext/GitTasks/GitLogTaskTest.php
@@ -149,7 +149,7 @@ class GitLogTaskTest extends BuildFileTest
     public function testGitOutputPropertySet()
     {
         $this->executeTarget('gitLogOutputPropertySet');
-        $this->assertPropertyEquals('gitLogOutput', '1b767b75bb5329f4e53345c516c0a9f4ed32d330 Added file5' . "\n");
+        $this->assertPropertyEquals('gitLogOutput', '1b767b75bb5329f4e53345c516c0a9f4ed32d330 Added file5');
     }
 
     public function testGitLogNameStatus()


### PR DESCRIPTION
Fix issue with string coming back from executing the git log command not being trimmed.