### PR TITLE
VersionTask can manage 'v' prefix

### DIFF
--- a/docs/guide/en/source/appendixes/optionaltasks.xml
+++ b/docs/guide/en/source/appendixes/optionaltasks.xml
@@ -13839,7 +13839,7 @@ host="webserver" command="ls" /></programlisting>
             given file and writes it back to the file. The resulting version number is also
             published under supplied property.</para>
         <para>The version number in the text file is expected in the format of Major.Minor.Bugfix
-            (e.g. 1.3.2).</para>
+            (e.g. 1.3.2). Alternatively you can use 'v' as prefix (e.g. v1.3.2).</para>
         <table>
             <title>Attributes</title>
             <tgroup cols="5">
@@ -13882,7 +13882,7 @@ host="webserver" command="ls" /></programlisting>
                     <row>
                         <entry><literal>propFile</literal></entry>
                         <entry><literal role="type">Boolean</literal></entry>
-                        <entry>Set to true, if version should be saved as property file.</entry>
+                        <entry>If <literal>true</literal>, version will be saved using <emphasis>property file</emphasis> format (i.e. key=value).</entry>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
@@ -13899,6 +13899,7 @@ host="webserver" command="ls" /></programlisting>
         <sect2>
             <title>Example</title>
             <programlisting language="xml">&lt;version releasetype="Major" file="version.txt" property="version.number"/></programlisting>
+            <programlisting language="xml">&lt;version releasetype="Minor" startingVersion="v5.7" propFile="true"/></programlisting>
         </sect2>
 
     </sect1>

--- a/test/classes/phing/tasks/ext/VersionTaskTest.php
+++ b/test/classes/phing/tasks/ext/VersionTaskTest.php
@@ -83,4 +83,143 @@ class VersionTaskTest extends BuildFileTest
         $this->assertPropertyEquals('build.version', '1.0.1');
         $this->assertFileExists(PHING_TEST_BASE . "/etc/tasks/ext/" . 'build.version', 'File not found');
     }
+
+    /**
+     * Testing \VersionTask::getVersion
+     *
+     * @dataProvider versionProvider
+     *
+     */
+    public function testGetVersionMethod($releaseType, $version, $expectedVersion)
+    {
+        $versionTask = new VersionTask();
+        $versionTask->setReleasetype($releaseType);
+
+        $reflector = new \ReflectionObject($versionTask);
+        $method = $reflector->getMethod('getVersion');
+        $method->setAccessible(true);
+
+        $newVersion = $method->invoke($versionTask, $version);
+        $this->assertSame($expectedVersion, $newVersion);
+    }
+
+    public function versionProvider()
+    {
+        return [
+            [VersionTask::RELEASETYPE_MAJOR, null, '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'x', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '0', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v0', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'a3', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v3', 'v4.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'qsdf', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'vvvv', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '0.6', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v0.6', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '5.0', '6.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v5.0', 'v6.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '5.5', '6.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v5.5', 'v6.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '0.0.0', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v0.0.0', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '0.0.15', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v0.0.15', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '0.1.15', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v0.1.15', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '7.0.15', '8.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v7.0.15', 'v8.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '2.3.4', '3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v2.3.4', 'v3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '2-RC1', '3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v2-RC1', 'v3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '2.3-RC1', '3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v2.3-RC1', 'v3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '2.3.4-RC1', '3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v2.3.4-RC1', 'v3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '2.3v654.4', '3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v2.3v56465.4-RC1', 'v3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, '2.hello.world', '3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'v2.hello.world', 'v3.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'hello.world.3', '1.0.0'],
+            [VersionTask::RELEASETYPE_MAJOR, 'vhello.world.3', 'v1.0.0'],
+            [VersionTask::RELEASETYPE_MINOR, null, '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'x', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v', 'v0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '0', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v0', 'v0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'a3', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v3', 'v3.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'qsdf', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'vvvv', 'v0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '0.6', '0.7.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v0.6', 'v0.7.0'],
+            [VersionTask::RELEASETYPE_MINOR, '5.0', '5.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v5.0', 'v5.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '5.5', '5.6.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v5.5', 'v5.6.0'],
+            [VersionTask::RELEASETYPE_MINOR, '0.0.0', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v0.0.0', 'v0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '0.0.15', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v0.0.15', 'v0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '0.1.15', '0.2.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v0.1.15', 'v0.2.0'],
+            [VersionTask::RELEASETYPE_MINOR, '7.0.15', '7.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v7.0.15', 'v7.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '2.3.4', '2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v2.3.4', 'v2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, '2-RC1', '2.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v2-RC1', 'v2.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, '2.3-RC1', '2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v2.3-RC1', 'v2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, '2.3.4-RC1', '2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v2.3.4-RC1', 'v2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, '2.3v654.4', '2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v2.3v56465.4-RC1', 'v2.4.0'],
+            [VersionTask::RELEASETYPE_MINOR, '2.hello.world', '2.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'v2.hello.world', 'v2.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'hello.world.3', '0.1.0'],
+            [VersionTask::RELEASETYPE_MINOR, 'vhello.world.3', 'v0.1.0'],
+            [VersionTask::RELEASETYPE_BUGFIX, null, '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '', '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'x', '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v', 'v0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '0', '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v0', 'v0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'a3', '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v3', 'v3.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'qsdf', '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'vvvv', 'v0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '0.6', '0.6.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v0.6', 'v0.6.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '5.0', '5.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v5.0', 'v5.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '5.5', '5.5.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v5.5', 'v5.5.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '0.0.0', '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v0.0.0', 'v0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '0.0.15', '0.0.16'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v0.0.15', 'v0.0.16'],
+            [VersionTask::RELEASETYPE_BUGFIX, '0.1.15', '0.1.16'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v0.1.15', 'v0.1.16'],
+            [VersionTask::RELEASETYPE_BUGFIX, '7.0.15', '7.0.16'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v7.0.15', 'v7.0.16'],
+            [VersionTask::RELEASETYPE_BUGFIX, '2.3.4', '2.3.5'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v2.3.4', 'v2.3.5'],
+            [VersionTask::RELEASETYPE_BUGFIX, '2-RC1', '2.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v2-RC1', 'v2.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '2.3-RC1', '2.3.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v2.3-RC1', 'v2.3.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '2.3.4-RC1', '2.3.5'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v2.3.4-RC1', 'v2.3.5'],
+            [VersionTask::RELEASETYPE_BUGFIX, '2.3v654.4', '2.3.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v2.3v56465.4-RC1', 'v2.3.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, '2.hello.world', '2.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'v2.hello.world', 'v2.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'hello.world.3', '0.0.1'],
+            [VersionTask::RELEASETYPE_BUGFIX, 'vhello.world.3', 'v0.0.1'],
+        ];
+    }
 }


### PR DESCRIPTION
I modified VersionTask to be able to manage 'v' prefix in version numbers. I also updated the doc and added tests for \VersionTask::getVersion.

I deleted \VersionTask::checkStartingVersion since the regex I added implicitly checks the validity of version too.

