### PR TITLE
Fixed null pointer exception

### DIFF
--- a/test/classes/phing/BuildFileTest.php
+++ b/test/classes/phing/BuildFileTest.php
@@ -346,6 +346,7 @@ abstract class BuildFileTest extends TestCase
             $this->buildException = $ex;
             $found = false;
             while ($ex) {
+                $msg = $ex->getMessage();
                 if (false !== strpos($ex->getMessage(), $contains)) {
                     $found = true;
                 }
@@ -354,8 +355,8 @@ abstract class BuildFileTest extends TestCase
 
             if (!$found) {
                 $this->fail(
-                    "Should throw BuildException because '" . $cause . "' with message containing '" . $contains . "' (actual message '" . $ex->getMessage(
-                    ) . "' instead)"
+                    "Should throw BuildException because '" . $cause . "' with message containing '" . $contains
+                    . "' (actual message '" . $msg . "' instead)"
                 );
             }
 


### PR DESCRIPTION
If there is no previous exception inside a failing test, there would be a null pointer exception then.