### PR TITLE
Avoid calling get_class on null in UnknownElement.

### DIFF
--- a/classes/phing/UnknownElement.php
+++ b/classes/phing/UnknownElement.php
@@ -117,7 +117,7 @@ class UnknownElement extends Task
             $parent = $parent->getProxy();
         }
 
-        $parentClass = get_class($parent);
+        $parentClass = $parent === null ? get_class() : get_class($parent);
         $ih = IntrospectionHelper::getHelper($parentClass);
 
         for ($i = 0, $childrenCount = count($this->children); $i < $childrenCount; $i++) {


### PR DESCRIPTION
Explicitly passing NULL to get_class triggers E_WARNING as of PHP 7.2[1].

[1] https://secure.php.net/get_class