### PR TITLE
Updated appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,50 +1,60 @@
 # http://www.appveyor.com/docs/appveyor-yml
 build: false
-shallow_clone: false
-platform:
-  - x64
 clone_folder: C:\projects\phing
+max_jobs: 3
+platform: x86
+pull_requests:
+  do_not_increment_build_number: true
+version: '{build}.{branch}'
 
 environment:
-    matrix:
-        - php_ver_target: 5.6
-        - php_ver_target: 7.0
+  COMPOSER_ROOT_VERSION: '7.0-dev'
+
+  matrix:
+    - PHP_VERSION: '7.1.11'
+      XDEBUG_VERSION: '2.5.5-7.1'
+      DEPENDENCIES: '--prefer-lowest'
+    - PHP_VERSION: '7.1.11'
+      XDEBUG_VERSION: '2.5.5-7.1'
+      DEPENDENCIES: ''
+
+matrix:
+  fast_finish: true
 
 cache:
-    - '%APPDATA%\Composer'
-    - C:\tools\php -> appveyor.yml
+  - c:\php -> appveyor.yml
+  - '%LOCALAPPDATA%\Composer\files'
 
 init:
-    - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
-    - SET COMPOSER_NO_INTERACTION=1
-    - SET PHP=1
-    - SET ANSICON=121x90 (121x90)
-
-branches:
-    except:
-        - gh-pages
+  - SET PATH=c:\php\%PHP_VERSION%;%PATH%
 
 install:
-    - IF EXIST c:\tools\php (SET PHP=0)
-    - IF %PHP%==1 cinst -y OpenSSL.Light
-    - ps: appveyor-retry cinst -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')
-    - cd C:\tools\php
-    - IF %PHP%==1 copy php.ini-production php.ini
-    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
-    - IF %PHP%==1 echo memory_limit=1024M >> php.ini
-    - IF %PHP%==1 echo extension_dir=ext >> php.ini
-    - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
-    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-    - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
-    - cd c:\projects\phing
-    - appveyor-retry composer install --no-progress --profile --prefer-dist --no-interaction
-
-before_test:
-    - php --version
+  - IF NOT EXIST c:\php mkdir c:\php
+  - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
+  - cd c:\php\%PHP_VERSION%
+  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC14-x86.zip https://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-Win32-VC14-x86.zip
+  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-VC14-x86.zip -y >nul
+  - IF NOT EXIST php-installed.txt del /Q *.zip
+  - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini
+  - IF NOT EXIST php-installed.txt echo max_execution_time=1200 >> php.ini
+  - IF NOT EXIST php-installed.txt echo date.timezone="UTC" >> php.ini
+  - IF NOT EXIST php-installed.txt echo extension_dir=ext >> php.ini
+  - IF NOT EXIST php-installed.txt echo extension=php_curl.dll >> php.ini
+  - IF NOT EXIST php-installed.txt echo extension=php_openssl.dll >> php.ini
+  - IF NOT EXIST php-installed.txt echo extension=php_mbstring.dll >> php.ini
+  - IF NOT EXIST php-installed.txt echo extension=php_fileinfo.dll >> php.ini
+  - IF NOT EXIST php-installed.txt echo extension=php_mysqli.dll >> php.ini
+  - IF NOT EXIST php-installed.txt echo extension=php_pdo_sqlite.dll >> php.ini
+  - IF NOT EXIST php-installed.txt echo zend.assertions=1 >> php.ini
+  - IF NOT EXIST php-installed.txt echo assert.exception=On >> php.ini
+  - IF NOT EXIST php-installed.txt curl -fsS -o composer.phar https://getcomposer.org/composer.phar
+  - IF NOT EXIST php-installed.txt echo @php %%~dp0composer.phar %%* > composer.bat
+  - IF NOT EXIST php-installed.txt curl -fsS -o c:\php\%PHP_VERSION%\ext\php_xdebug-%XDEBUG_VERSION%-vc14.dll https://xdebug.org/files/php_xdebug-%XDEBUG_VERSION%-vc14.dll
+  - IF NOT EXIST php-installed.txt echo zend_extension=php_xdebug-%XDEBUG_VERSION%-vc14.dll >> php.ini
+  - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
+  - cd C:\projects\phing
+  - composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable %DEPENDENCIES%
 
 test_script:
-    - cd C:\projects\phing\test
-    - ..\vendor\bin\phing
+  - cd C:\projects\phing\test
+  - ..\bin\phing.bat


### PR DESCRIPTION
Appveyor config needs to be updated to test against windows.
With this changes the test execution under windows is working again see https://ci.appveyor.com/project/siad007/phing
@mrook would you mind to have a look here and make an account on appveyor for phing, so we are able to check, if there would be any problem with phing running on windows systems? Then we could also put a badge on the readme indicating the status?