### PR TITLE
Added exception message to verbose output.

### DIFF
--- a/classes/phing/listener/DefaultLogger.php
+++ b/classes/phing/listener/DefaultLogger.php
@@ -187,7 +187,7 @@ class DefaultLogger implements StreamRequiredBuildLogger
             }
         }
         $msg .= $verbose || !$error instanceof BuildException
-            ? $error->getTraceAsString()
+            ? $error->getMessage() . PHP_EOL . $error->getTraceAsString() . PHP_EOL
             : $error->getLocation() . ' ' . $error->getMessage() . PHP_EOL;
     }
 


### PR DESCRIPTION
If in verbose mode or a not `BuildException` exception is thrown there is no error message available in the `DefaultLogger` output.