### PR TITLE
 Opened IoncubeEncoderTask to all php versions

### DIFF
--- a/classes/phing/tasks/ext/ioncube/IoncubeEncoderTask.php
+++ b/classes/phing/tasks/ext/ioncube/IoncubeEncoderTask.php
@@ -574,12 +574,7 @@ class IoncubeEncoderTask extends Task
     {
         $arguments = $this->constructArguments();
 
-        if (in_array($this->phpVersion, [5, 53, 54, 55, 56, 71])) {
-            $encoderName = $this->encoderName . $this->phpVersion;
-        } else {
-            $encoderName = $this->encoderName;
-        }
-        $encoder = new PhingFile($this->ioncubePath, $encoderName);
+        $encoder = new PhingFile($this->ioncubePath, $this->encoderName . $this->phpVersion);
 
         $this->log("Running ionCube Encoder...");
 

--- a/docs/guide/en/source/appendixes/optionaltasks.xml
+++ b/docs/guide/en/source/appendixes/optionaltasks.xml
@@ -5001,8 +5001,8 @@ Note that you can omit both startpoint and track attributes in this case
                     </row>
                     <row>
                         <entry><literal>phpversion</literal></entry>
-                        <entry><literal role="type">Integer</literal></entry>
-                        <entry>The PHP version to use</entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Defines which php encoder version will be used (suffix of the encoder file)</entry>
                         <entry>5</entry>
                         <entry>No</entry>
                     </row>


### PR DESCRIPTION
Every new php version we come to the problem that the phing task have to manually changed to support the new version. See #335 #485 #130 

To solve this once and for all the phpversion should be removed and allow everything given. So we can also finally use this x64 versions of ioncube encoder without renaming the encoder files.