### PR TITLE
Replaced deprecated create_function calls with anonymous functions.

### DIFF
--- a/classes/phing/tasks/ext/coverage/CoverageReportTask.php
+++ b/classes/phing/tasks/ext/coverage/CoverageReportTask.php
@@ -427,14 +427,18 @@ class CoverageReportTask extends Task
                 $statementcount = count(
                     array_filter(
                         $coverageInformation,
-                        create_function('$var', 'return ($var != -2);')
+                        function ($var) {
+                            return ($var != -2);
+                        }
                     )
                 );
 
                 $statementscovered = count(
                     array_filter(
                         $coverageInformation,
-                        create_function('$var', 'return ($var >= 0);')
+                        function ($var) {
+                            return ($var >= 0);
+                        }
                     )
                 );
 


### PR DESCRIPTION
create_function is deprecated in 7.2, but, anonymous functions have been supported since 5.3, so including this update in version 3 (which requires 7.1+) should be harmless.