### PR TITLE
Fixed single test execution of phpunit tests.

### DIFF
--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -8,9 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
-         verbose="true"
-         strict="false">
+         verbose="true">
     <testsuites>
         <testsuite name="AllTests">
             <directory>classes/phing/</directory>
@@ -24,8 +22,7 @@
 
     <filter>
         <whitelist>
-            <directory suffix=".php">../classes/phing/tasks/</directory>
-            <directory suffix=".php">../classes/phing/system/</directory>
+            <directory suffix=".php">../classes/phing/</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
It is not possible to execute unit tests with codecoverage of a single phpunit file.
Example: running `PhingTest` as phpunit test under phpstorm wich will execute:
```
php.exe -dxdebug.coverage_enable=1 C:\XXX\phing/vendor/phpunit/phpunit/phpunit --coverage-clover C:\XXX\.PhpStorm2018.3\system\coverage\phingPhpArrayRebase$PhingTest.xml --configuration C:\XXX\phing\test\phpunit.xml PhingTest C:\XXX\phing\test\classes\phing\PhingTest.php --teamcity
```
will end with:
```
PHPUnit 7.5.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.8 with Xdebug 2.5.5
Configuration: C:\XXX\phing\test\phpunit.xml

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 13:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.
  - Element 'phpunit', attribute 'strict': The attribute 'strict' is not allowed.

  Test results may not be as expected.




Time: 1.01 seconds, Memory: 10.00MB

OK (3 tests, 17 assertions)

Generating code coverage report in Clover XML format ... done

Process finished with exit code 0
```
with no coverage generated inside the IDE.

So I removed `syntaxCheck` and `strict` attribute from `phpunit.xml` and extended the whitelist. 