### PR TITLE
phing wouldn't work from the test directory, document how I got it to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Then, perform the following steps (on a clone/fork of Phing):
          $ cd test
          $ ../bin/phing
 
+Should this not work, you might be able to run the unit tests from the main directory:
+
+         $ $ ./bin/phing -f test/build.xml -Dtest=NotifyTaskTest
+
 ## Licensing
 
   This software is licensed under the terms you may find in the file


### PR DESCRIPTION
phing kept throwing an error, as shown below, when attempting to run it from the test directory.
got it to run by doing this from root directory instead...
```
$ ./bin/phing -f test/build.xml -Dtest=NotifyTaskTest

Phing Build Tests > initialize:


Phing Build Tests > configure:

     [echo] -------------------------------------------------
     [echo]  +++++ Running Phing  unit tests
     [echo] -------------------------------------------------

Phing Build Tests > reports:

   [delete] Deleting directory /home/kguest/dev/code/phing/test/tmp
    [mkdir] Created dir: /home/kguest/dev/code/phing/test/tmp
#!/usr/bin/env php
```