### PR TITLE
Update obsolete phpstan --errorFormat flag with correct one

### DIFF
--- a/classes/phing/tasks/ext/phpstan/CommandBuilder/PHPStanAnalyseCommandBuilder.php
+++ b/classes/phing/tasks/ext/phpstan/CommandBuilder/PHPStanAnalyseCommandBuilder.php
@@ -67,7 +67,7 @@ class PHPStanAnalyseCommandBuilder extends PHPStanCommandBuilder
     private function buildErrorFormat(PHPStanTask $task): ?string
     {
         if (!empty($task->getErrorFormat())) {
-            return '--errorFormat=' . $task->getErrorFormat();
+            return '--error-format=' . $task->getErrorFormat();
         }
         return null;
     }

--- a/test/classes/phing/tasks/ext/PHPStanTask/Acceptance/PHPStanTaskTest.php
+++ b/test/classes/phing/tasks/ext/PHPStanTask/Acceptance/PHPStanTaskTest.php
@@ -57,7 +57,7 @@ class PHPStanTaskTest extends BuildFileTest
         $expectedCommand .= ' --no-progress';
         $expectedCommand .= ' --debug';
         $expectedCommand .= ' --autoload-file=anyAutoloadFile';
-        $expectedCommand .= ' --errorFormat=anyErrorFormat';
+        $expectedCommand .= ' --error-format=anyErrorFormat';
         $expectedCommand .= ' --memory-limit=anyMemoryLimit';
         $expectedCommand .= ' path1 path2';
 

--- a/test/classes/phing/tasks/ext/PHPStanTask/Unit/CommandBuilder/PHPStanAnalyseCommandBuilderTest.php
+++ b/test/classes/phing/tasks/ext/PHPStanTask/Unit/CommandBuilder/PHPStanAnalyseCommandBuilderTest.php
@@ -38,7 +38,7 @@ class PHPStanAnalyseCommandBuilderTest extends TestCase
         $expectedCommand .= ' --no-progress';
         $expectedCommand .= ' --debug';
         $expectedCommand .= ' --autoload-file=anyAutoloadFile';
-        $expectedCommand .= ' --errorFormat=anyErrorFormat';
+        $expectedCommand .= ' --error-format=anyErrorFormat';
         $expectedCommand .= ' --memory-limit=anyMemoryLimit';
         $expectedCommand .= ' path1 path2';
 


### PR DESCRIPTION
The deprecated flag was removed in this commit https://github.com/phpstan/phpstan/commit/12545aca186fe3858a88ee49494c4a589845773c