### PR TITLE
Fix some PHP 7.4 specific deprecations.

### DIFF
--- a/classes/phing/PropertyHelper.php
+++ b/classes/phing/PropertyHelper.php
@@ -563,7 +563,7 @@ class PropertyHelper
             if ($pos === (strlen($value) - 1)) {
                 $fragments[] = '$';
                 $prev = $pos + 1;
-            } elseif ($value{$pos + 1} !== '{') {
+            } elseif ($value[$pos + 1] !== '{') {
                 // the string positions were changed to value-1 to correct
                 // a fatal error coming from function substring()
                 $fragments[] = StringHelper::substring($value, $pos, $pos + 1);

--- a/classes/phing/parser/CustomChildCreator.php
+++ b/classes/phing/parser/CustomChildCreator.php
@@ -33,5 +33,5 @@ interface CustomChildCreator
      * @param  Project $project The project the element is in
      * @return object  Returns the nested element
      */
-    public function __construct($elementName, Project $project);
+    public function customChildCreator($elementName, Project $project);
 }

--- a/classes/phing/parser/CustomChildCreator.php
+++ b/classes/phing/parser/CustomChildCreator.php
@@ -33,5 +33,5 @@ interface CustomChildCreator
      * @param  Project $project The project the element is in
      * @return object  Returns the nested element
      */
-    public function customChildCreator($elementName, Project $project);
+    public function __construct($elementName, Project $project);
 }

--- a/classes/phing/system/io/BufferedReader.php
+++ b/classes/phing/system/io/BufferedReader.php
@@ -150,7 +150,7 @@ class BufferedReader extends Reader
             // Get next buffered char ...
             // handle case where buffer is read-in, but is empty.  The next readChar() will return -1 EOF,
             // so we just return empty string (char) at this point.  (Probably could also return -1 ...?)
-            $ch = ($this->buffer !== "") ? $this->buffer{$this->bufferPos} : '';
+            $ch = ($this->buffer !== "") ? $this->buffer[$this->bufferPos] : '';
             $this->bufferPos++;
             if ($this->bufferPos >= strlen($this->buffer)) {
                 $this->buffer = null;

--- a/classes/phing/system/io/WindowsFileSystem.php
+++ b/classes/phing/system/io/WindowsFileSystem.php
@@ -63,7 +63,7 @@ class WindowsFileSystem extends FileSystem
      */
     public function slashify($p)
     {
-        if ((strlen($p) > 0) && ($p{0} != $this->slash)) {
+        if ((strlen($p) > 0) && ($p[0] != $this->slash)) {
             return $this->slash . $p;
         }
 
@@ -109,13 +109,13 @@ class WindowsFileSystem extends FileSystem
     public function normalizePrefix($strPath, $len, &$sb)
     {
         $src = 0;
-        while (($src < $len) && $this->isSlash($strPath{$src})) {
+        while (($src < $len) && $this->isSlash($strPath[$src])) {
             $src++;
         }
         $c = "";
         if (($len - $src >= 2)
-            && $this->isLetter($c = $strPath{$src})
-            && $strPath{$src + 1} === ':'
+            && $this->isLetter($c = $strPath[$src])
+            && $strPath[$src + 1] === ':'
         ) {
             /* Remove leading slashes if followed by drive specifier.
              * This hack is necessary to support file URLs containing drive
@@ -127,8 +127,8 @@ class WindowsFileSystem extends FileSystem
         } else {
             $src = 0;
             if (($len >= 2)
-                && $this->isSlash($strPath{0})
-                && $this->isSlash($strPath{1})
+                && $this->isSlash($strPath[0])
+                && $this->isSlash($strPath[1])
             ) {
                 /* UNC pathname: Retain first slash; leave src pointed at
                  * second slash so that further slashes will be collapsed
@@ -176,15 +176,15 @@ class WindowsFileSystem extends FileSystem
         // Remove redundant slashes from the remainder of the path, forcing all
         // slashes into the preferred slash
         while ($src < $len) {
-            $c = $strPath{$src++};
+            $c = $strPath[$src++];
             if ($this->isSlash($c)) {
-                while (($src < $len) && $this->isSlash($strPath{$src})) {
+                while (($src < $len) && $this->isSlash($strPath[$src])) {
                     $src++;
                 }
                 if ($src === $len) {
                     /* Check for trailing separator */
                     $sn = (int) strlen($sb);
-                    if (($sn == 2) && ($sb{1} === ':')) {
+                    if (($sn == 2) && ($sb[1] === ':')) {
                         // "z:\\"
                         $sb .= $slash;
                         break;
@@ -194,7 +194,7 @@ class WindowsFileSystem extends FileSystem
                         $sb .= $slash;
                         break;
                     }
-                    if (($sn === 1) && ($this->isSlash($sb{0}))) {
+                    if (($sn === 1) && ($this->isSlash($sb[0]))) {
                         /* "\\\\" is not collapsed to "\\" because "\\\\" marks
                         the beginning of a UNC pathname.  Even though it is
                         not, by itself, a valid UNC pathname, we leave it as
@@ -241,7 +241,7 @@ class WindowsFileSystem extends FileSystem
         $altSlash = $this->altSlash;
         $prev = 0;
         for ($i = 0; $i < $n; $i++) {
-            $c = $strPath{$i};
+            $c = $strPath[$i];
             if ($c === $altSlash) {
                 return $this->normalizer($strPath, $n, ($prev === $slash) ? $i - 1 : $i);
             }
@@ -276,8 +276,8 @@ class WindowsFileSystem extends FileSystem
         if ($n === 0) {
             return 0;
         }
-        $c0 = $path{0};
-        $c1 = ($n > 1) ? $path{1} :
+        $c0 = $path[0];
+        $c1 = ($n > 1) ? $path[1] :
             0;
         if ($c0 === $slash) {
             if ($c1 === $slash) {
@@ -288,7 +288,7 @@ class WindowsFileSystem extends FileSystem
         }
 
         if ($this->isLetter($c0) && ($c1 === ':')) {
-            if (($n > 2) && ($path{2}) === $slash) {
+            if (($n > 2) && ($path[2]) === $slash) {
                 return 3; // Absolute local pathname "z:\\foo" */
             }
 
@@ -319,8 +319,8 @@ class WindowsFileSystem extends FileSystem
         }
 
         $c = $child;
-        if (($cn > 1) && ($c{0} === $slash)) {
-            if ($c{1} === $slash) {
+        if (($cn > 1) && ($c[0] === $slash)) {
+            if ($c[1] === $slash) {
                 // drop prefix when child is a UNC pathname
                 $c = substr($c, 2);
             } else {
@@ -330,7 +330,7 @@ class WindowsFileSystem extends FileSystem
         }
 
         $p = $parent;
-        if ($p{$pn - 1} === $slash) {
+        if ($p[$pn - 1] === $slash) {
             $p = substr($p, 0, $pn - 1);
         }
 
@@ -352,7 +352,7 @@ class WindowsFileSystem extends FileSystem
     public function fromURIPath($strPath)
     {
         $p = (string) $strPath;
-        if ((strlen($p) > 2) && ($p{2} === ':')) {
+        if ((strlen($p) > 2) && ($p[2] === ':')) {
             // "/c:/foo" --> "c:/foo"
             $p = substr($p, 1);
 
@@ -379,7 +379,7 @@ class WindowsFileSystem extends FileSystem
         $pl = (int) $f->getPrefixLength();
         $p = (string) $f->getPath();
 
-        return ((($pl === 2) && ($p{0} === $this->slash)) || ($pl === 3) || ($pl === 1 && $p{0} === $this->slash));
+        return ((($pl === 2) && ($p[0] === $this->slash)) || ($pl === 3) || ($pl === 1 && $p[0] === $this->slash));
     }
 
     /**
@@ -390,7 +390,7 @@ class WindowsFileSystem extends FileSystem
      */
     public function _driveIndex($d)
     {
-        $d = (string) $d{0};
+        $d = (string) $d[0];
         if ((ord($d) >= ord('a')) && (ord($d) <= ord('z'))) {
             return ord($d) - ord('a');
         }
@@ -418,7 +418,7 @@ class WindowsFileSystem extends FileSystem
      */
     public function _getDriveDirectory($drive)
     {
-        $drive = (string) $drive{0};
+        $drive = (string) $drive[0];
         $i = (int) $this->_driveIndex($drive);
         if ($i < 0) {
             return null;
@@ -465,7 +465,7 @@ class WindowsFileSystem extends FileSystem
         $path = $f->getPath();
         $pl = (int) $f->getPrefixLength();
 
-        if (($pl === 2) && ($path{0} === $this->slash)) {
+        if (($pl === 2) && ($path[0] === $this->slash)) {
             return $path; // UNC
         }
 
@@ -497,7 +497,7 @@ class WindowsFileSystem extends FileSystem
             if (($ud !== null) && StringHelper::startsWith($ud, $path)) {
                 return (string) ($up . $this->slashify(substr($path, 2)));
             }
-            $drive = (string) $path{0};
+            $drive = (string) $path[0];
             $dir = (string) $this->_getDriveDirectory($drive);
 
             if ($dir !== null) {

--- a/classes/phing/types/Path.php
+++ b/classes/phing/types/Path.php
@@ -448,8 +448,8 @@ class Path extends DataType
      */
     protected static function translateFileSep(&$buffer, $pos)
     {
-        if ($buffer{$pos} == '/' || $buffer{$pos} == '\\') {
-            $buffer{$pos} = DIRECTORY_SEPARATOR;
+        if ($buffer[$pos] == '/' || $buffer[$pos] == '\\') {
+            $buffer[$pos] = DIRECTORY_SEPARATOR;
 
             return true;
         }

--- a/classes/phing/util/PathTokenizer.php
+++ b/classes/phing/util/PathTokenizer.php
@@ -107,7 +107,7 @@ class PathTokenizer
         }
 
 
-        if (strlen($token) === 1 && Character::isLetter($token{0})
+        if (strlen($token) === 1 && Character::isLetter($token[0])
             && $this->dosStyleFilesystem
             && !empty($this->tokens)
         ) {

--- a/test/classes/phing/BuildFileTest.php
+++ b/test/classes/phing/BuildFileTest.php
@@ -228,7 +228,7 @@ abstract class BuildFileTest extends TestCase
         $cleanedBuffer = "";
         $cr = false;
         for ($i = 0, $bufflen = strlen($buffer); $i < $bufflen; $i++) {
-            $ch = $buffer{$i};
+            $ch = $buffer[$i];
             if ($ch == "\r") {
                 $cr = true;
                 continue;


### PR DESCRIPTION
curly brace syntax for accessing array elements and string offsets is deprecated in PHP 7.4.
