### PR TITLE
add Build-Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,17 @@ language: php
 
 sudo: false
 
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
+  - master
+
+env:
+  - DEPS="LOW"
+  - DEPS="NORMAL"
+
 addons:
   apt:
     packages:
@@ -12,58 +23,89 @@ cache:
     - $HOME/.composer/cache
     - build/cache
 
+stages:
+  - composer validate
+  - static code analysis
+  - test
+  - test with coverage
+
+before_install:
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
+  - phpenv config-add .travis.php.ini
+  - phpenv rehash
+  - echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo 'zend.assertions=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'assert.exception=On' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - set -e
+  - pear config-set php_dir $(php -r 'echo substr(get_include_path(),2);')
+  - echo "=== SETTING GIT IDENTITY ==="
+  - git config --global user.email "travis-ci-build@phing.info"
+  - git config --global user.name "Phing Travis Builder"
+  - composer self-update
+
 install:
   - |
-    set -e
-    pear config-set php_dir $(php -r 'echo substr(get_include_path(),2);')
     if [[ "$DEPS" == "LOW" ]]; then
-      composer install -n;
-      composer update --prefer-lowest;
+      composer install --prefer-dist --no-progress --no-interaction --no-suggest;
+      composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest --prefer-lowest;
     else
-      composer install -o --no-progress --prefer-dist;
+      composer install --optimize-autoloader --prefer-dist --no-progress --no-interaction --no-suggest;
     fi
-    phpenv config-add .travis.php.ini;
-    phpenv rehash;
-    echo "=== SETTING GIT IDENTITY ===";
-    git config --global user.email "travis-ci-build@phing.info";
-    git config --global user.name "Phing Travis Builder";
+
 script:
-  - |
-    if [[ "$PHPCS" == "TRUE" ]]; then
-      bin/phpcs -n --standard=./ruleset.xml classes
-    else
-      echo "=== TESTING PHING ==="
-      cd test
-      ../bin/phing -Dtests.codecoverage=true -listener "phing.listener.StatisticsListener"
-      cd ..
-    fi
-after_success:
-  - |
-    if [[ "$PHPCS" != "TRUE" ]]; then
-      if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-        bash <(curl -s https://codecov.io/bash)
-      fi
-      wget https://scrutinizer-ci.com/ocular.phar
-      php ocular.phar code-coverage:upload --format=clover ./test/reports/clover-coverage.xml
-    fi
+  - echo "=== TESTING PHING ==="
+  - cd test
+  - ../bin/phing -debug -Dtests.codecoverage=false -listener "phing.listener.StatisticsListener"
+  - cd ..
 
-php:
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4snapshot
-  - master
-
-matrix:
-  include:
-    - php: 7.2
-      env: PHPCS="TRUE"
-    - php: 7.1
-      env: DEPS="LOW"
-  fast_finish: true
+jobs:
   allow_failures:
     - php: 7.4snapshot
     - php: master
+    - php: nightly
+  include:
+    - php: nightly
+      env: DEPS="IGNORE"
+      install: composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest --ignore-platform-reqs
+
+    - stage: test with coverage
+      php: 7.2
+      env: DEPS="NORMAL"
+      before_install:
+        - phpenv config-add .travis.php.ini
+        - phpenv rehash
+        - echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+        - echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+        - echo 'zend.assertions=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+        - echo 'assert.exception=On' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+        - set -e
+        - pear config-set php_dir $(php -r 'echo substr(get_include_path(),2);')
+        - echo "=== SETTING GIT IDENTITY ==="
+        - git config --global user.email "travis-ci-build@phing.info"
+        - git config --global user.name "Phing Travis Builder"
+        - composer self-update
+      script:
+        - echo "=== TESTING PHING ==="
+        - cd test
+        - ../bin/phing -Dtests.codecoverage=true -listener "phing.listener.StatisticsListener"
+        - cd ..
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -f ./test/reports/clover-coverage.xml
+        - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=clover ./test/reports/clover-coverage.xml
+
+    - stage: composer validate
+      os: linux
+      php: 7.2
+      env: DEPS="NORMAL"
+      script:
+        - composer validate
+
+    - stage: static code analysis
+      os: linux
+      php: 7.2
+      env: DEPS="NORMAL"
+      script: bin/phpcs -s --standard=./ruleset.xml classes
 
 notifications:
   secure: "Q8xCtM0IMQyjQuPJOPFCcFvBUlD7zwg6E5vEFfsaFQj+9bJ83Xo3loURsizTBf+WpRruDxmu3tlg0GNk5yDt92POOCOISzyWPBDmHiy2MVDfINEwyNsJpzdlw1UnChoTjSwRS3goPivfQDkOsbSrszLE93iE9PIIUw5BV4CAoho="

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ jobs:
       os: linux
       php: 7.2
       env: DEPS="NORMAL"
-      script: bin/phpcs -s --standard=./ruleset.xml classes
+      script: bin/phpcs -s -n --standard=./ruleset.xml classes
 
 notifications:
   secure: "Q8xCtM0IMQyjQuPJOPFCcFvBUlD7zwg6E5vEFfsaFQj+9bJ83Xo3loURsizTBf+WpRruDxmu3tlg0GNk5yDt92POOCOISzyWPBDmHiy2MVDfINEwyNsJpzdlw1UnChoTjSwRS3goPivfQDkOsbSrszLE93iE9PIIUw5BV4CAoho="


### PR DESCRIPTION
This PR wants to add a Build-Matrix to make the travis file more readable and group the tests.

As a result
- as first step the composer.json and composer.lock are validated
- as second step the coding style is checked
- for each PHP version the project is installed with lowest and normal dependency versions
- for each PHP version PHPUnit is run without XDebug to make the tests faster
- an additional test is run on the nightly build of PHP without dependency limits
- as last step PHPUnit is run with XDebug

This PR is related to PR #1129.