### PR TITLE
add *.test to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 *.xml   text eol=lf
 *.ini   text eol=lf
 *.sh    text eol=lf
+*.test  text eol=lf
 hlsaxon text eol=lf
 
 .dockerignore text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 .buildpath
 .project
 .settings
-.idea
+.idea/
 build/full
 build/pear
-test/reports
+test/reports/
 docs/api/docs
-vendor
+vendor/
 bin/*
 !bin/pear*
 !bin/phing*


### PR DESCRIPTION
There are some *.test files in this project. These got the line endings changed on my windows system. To prevent this, I added the to the .gitattrbutes file.

There also a *.log.txt file was generated somehow (I dont remember). Like the *.log files I added these files to the .gitignore file.