### PR TITLE
replace ignore-checks in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/*
 ansible/playbook.retry
 test/etc/tasks/system/defaultexcludestestinput/
 test/etc/types/selectors/tmp/
+test/tmp/

--- a/test/classes/phing/PhingTest.php
+++ b/test/classes/phing/PhingTest.php
@@ -24,7 +24,6 @@
  * // TODO implement all methods
  *
  * @author Kirill chEbba Chebunin <iam@chebba.org>
- * @version $Revision: $
  * @package phing
  */
 class PhingTest extends \PHPUnit\Framework\TestCase

--- a/test/classes/phing/regression/ExcludeZipTest.php
+++ b/test/classes/phing/regression/ExcludeZipTest.php
@@ -22,14 +22,13 @@
  * - Excluded files may be included in Zip/Tar tasks
  *
  * @package phing.regression
+ *
+ * @requires extension zip
  */
 class ExcludeZipTest extends BuildFileTest
 {
     public function setUp(): void
     {
-        if (!extension_loaded('zip')) {
-            $this->markTestSkipped("Zip extension is required");
-        }
         $this->configureProject(PHING_TEST_BASE . "/etc/regression/137/build.xml");
     }
 

--- a/test/classes/phing/regression/PearPkg2CompatibilityTest.php
+++ b/test/classes/phing/regression/PearPkg2CompatibilityTest.php
@@ -28,7 +28,6 @@
 class PearPkg2CompatibilityTest extends BuildFileTest
 {
     private $savedErrorLevel;
-    protected $backupGlobals = false;
 
     public function setUp(): void
     {
@@ -36,10 +35,6 @@ class PearPkg2CompatibilityTest extends BuildFileTest
         error_reporting(E_ERROR);
         $buildFile = PHING_TEST_BASE . "/etc/regression/524/build.xml";
         $this->configureProject($buildFile);
-
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PEAR tests do not run on HHVM");
-        }
 
         if (!class_exists('PEAR_PackageFileManager', false)) {
             $this->markTestSkipped("This test requires PEAR_PackageFileManager to be installed");

--- a/test/classes/phing/system/condition/SocketConditionTest.php
+++ b/test/classes/phing/system/condition/SocketConditionTest.php
@@ -21,6 +21,8 @@
  * Tests for the <socket> condition
  *
  * @package phing.tasks.system.condition
+ *
+ * @requires extension sockets
  */
 class SocketConditionTest extends \PHPUnit\Framework\TestCase
 {

--- a/test/classes/phing/system/io/AbstractWinFileSystemTestCase.php
+++ b/test/classes/phing/system/io/AbstractWinFileSystemTestCase.php
@@ -31,11 +31,6 @@ abstract class AbstractWinFileSystemTestCase extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-            $this->markTestSkipped(
-                'Testing not on a windows os.'
-            );
-        }
         $this->fs = $this->createFileSystem();
     }
 

--- a/test/classes/phing/system/io/WindowsFileSystemTest.php
+++ b/test/classes/phing/system/io/WindowsFileSystemTest.php
@@ -22,6 +22,8 @@
  *
  * @author Daniel Holmes
  * @package phing.system.io
+ *
+ * @requires OS WIN32|WINNT
  */
 class WindowsFileSystemTest extends AbstractWinFileSystemTestCase
 {

--- a/test/classes/phing/tasks/ext/DbDeployTaskTest.php
+++ b/test/classes/phing/tasks/ext/DbDeployTaskTest.php
@@ -20,15 +20,13 @@
 /**
  * @author Michiel Rook <mrook@php.net>
  * @package phing.tasks.ext
+ *
+ * @requires extension sqlite
  */
 class DbDeployTaskTest extends BuildFileTest
 {
     public function setUp(): void
     {
-        if (!extension_loaded('sqlite')) {
-            $this->markTestSkipped('This test require sqlite extension to be loaded');
-        }
-
         $this->configureProject(PHING_TEST_BASE . "/etc/tasks/ext/dbdeploy/build.xml");
         $this->executeTarget("prepare");
     }

--- a/test/classes/phing/tasks/ext/PHPLOCTaskTest.php
+++ b/test/classes/phing/tasks/ext/PHPLOCTaskTest.php
@@ -22,15 +22,13 @@
  *
  * @author Michiel Rook <mrook@php.net>
  * @package phing.tasks.ext
+ *
+ * @requires PHP < 7.3
  */
 class PHPLOCTaskTest extends BuildFileTest
 {
     public function setUp(): void
     {
-        if (PHP_VERSION_ID >= 70300) {
-            $this->markTestSkipped('phploc task is not running on PHP 7.3');
-        }
-
         $this->configureProject(PHING_TEST_BASE . "/etc/tasks/ext/phploc/build.xml");
     }
 

--- a/test/classes/phing/tasks/ext/PearPackageTest.php
+++ b/test/classes/phing/tasks/ext/PearPackageTest.php
@@ -25,8 +25,6 @@
  */
 class PearPackageTest extends BuildFileTest
 {
-    protected $backupGlobals = false;
-
     private $savedErrorLevel;
 
     public function setUp(): void
@@ -35,10 +33,6 @@ class PearPackageTest extends BuildFileTest
         error_reporting(E_ERROR);
         $buildFile = PHING_TEST_BASE . "/etc/tasks/ext/pearpackage.xml";
         $this->configureProject($buildFile);
-
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PEAR tests do not run on HHVM");
-        }
 
         if (!class_exists('PEAR_PackageFileManager', false)) {
             $this->markTestSkipped("This test requires PEAR_PackageFileManager to be installed");

--- a/test/classes/phing/tasks/ext/PharDataTaskTest.php
+++ b/test/classes/phing/tasks/ext/PharDataTaskTest.php
@@ -25,16 +25,11 @@
  */
 class PharDataTaskTest extends BuildFileTest
 {
+    /**
+     * @requires extension phar
+     */
     public function setUp(): void
     {
-        if (!extension_loaded('phar')) {
-            $this->markTestSkipped("PharDataTask require either PHP 5.3 or better or the PECL's Phar extension");
-        }
-
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PHAR tests do not run on HHVM");
-        }
-
         $this->configureProject(
             PHING_TEST_BASE
             . "/etc/tasks/ext/PharDataTaskTest.xml"

--- a/test/classes/phing/tasks/ext/PharPackageTaskTest.php
+++ b/test/classes/phing/tasks/ext/PharPackageTaskTest.php
@@ -23,6 +23,7 @@
  * @author François Poirotte <clicky@erebot.net>
  * @package phing.tasks.ext
  * @requires extension phar
+ * @requires extension openssl
  */
 class PharPackageTaskTest extends BuildFileTest
 {
@@ -30,10 +31,6 @@ class PharPackageTaskTest extends BuildFileTest
     {
         if (ini_get('phar.readonly') == "1") {
             $this->markTestSkipped("This test require phar.readonly php.ini setting to be disabled");
-        }
-
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PHAR tests do not run on HHVM");
         }
 
         $this->configureProject(PHING_TEST_BASE . "/etc/tasks/ext/pharpackage/build.xml");

--- a/test/classes/phing/tasks/ext/PhpCodeSnifferTaskTest.php
+++ b/test/classes/phing/tasks/ext/PhpCodeSnifferTaskTest.php
@@ -27,10 +27,6 @@ class PhpCodeSnifferTaskTest extends BuildFileTest
 {
     public function setUp(): void
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PHP CodeSniffer tests do not (yet) run on HHVM");
-        }
-
         if (!class_exists('PHP_CodeSniffer')) {
             $this->markTestSkipped('PHP CodeSniffer package not available.');
         }

--- a/test/classes/phing/tasks/ext/PhpLintTaskTest.php
+++ b/test/classes/phing/tasks/ext/PhpLintTaskTest.php
@@ -52,13 +52,11 @@ class PhpLintTaskTest extends BuildFileTest
 
     /**
      * Regression test for ticket http://www.phing.info/trac/ticket/590
+     *
+     * @requires PHP < 7.0
      */
     public function testDeprecated()
     {
-        if (defined('HHVM_VERSION') || PHP_MAJOR_VERSION > 5) {
-            $this->markTestSkipped("Testing for deprecated statements only works on PHP 5.x");
-        }
-
         file_put_contents(
             PHING_TEST_BASE . '/tmp/phplint_file.php',
             '<?php class TestClass {}; $t = & new TestClass();'

--- a/test/classes/phing/tasks/ext/VisualizerTaskTest.php
+++ b/test/classes/phing/tasks/ext/VisualizerTaskTest.php
@@ -17,6 +17,9 @@
  * <http://phing.info>.
  */
 
+/**
+ * @requires extension xsl
+ */
 class VisualizerTaskTest extends BuildFileTest
 {
     public function setUp(): void

--- a/test/classes/phing/tasks/ext/ZipUnzipTaskTest.php
+++ b/test/classes/phing/tasks/ext/ZipUnzipTaskTest.php
@@ -22,14 +22,13 @@
  *
  * @author  Michiel Rook <mrook@php.net>
  * @package phing.tasks.ext
+ *
+ * @requires extension zip
  */
 class ZipUnzipTaskTest extends BuildFileTest
 {
     public function setUp(): void
     {
-        if (!extension_loaded('zip')) {
-            $this->markTestSkipped("Zip extension is required");
-        }
         $this->configureProject(
             PHING_TEST_BASE
             . "/etc/tasks/ext/ZipUnzipTaskTest.xml"

--- a/test/classes/phing/tasks/ext/property/VariableTest.php
+++ b/test/classes/phing/tasks/ext/property/VariableTest.php
@@ -33,11 +33,11 @@ class VariableTest extends BuildFileTest
         );
     }
 
+    /**
+     * @requires PHP > 5.3
+     */
     public function testVariable()
     {
-        if (version_compare(PHP_VERSION, '5.3', '<')) {
-            $this->markTestSkipped('PHP Version less than 5.3');
-        }
         $this->executeTarget(__FUNCTION__);
 
         $this->assertInLogs('1: aazz');

--- a/test/classes/phing/tasks/ext/rST/RSTTaskTest.php
+++ b/test/classes/phing/tasks/ext/rST/RSTTaskTest.php
@@ -72,38 +72,35 @@ class RSTTaskTest extends BuildFileTest
         unlink(PHING_TEST_BASE . '/etc/tasks/ext/rst/' . $file);
     }
 
+    /**
+     * @requires function ReflectionMethod::setAccessible
+     */
     public function testGetToolPathFail()
     {
-        if (method_exists('ReflectionMethod', 'setAccessible')) {
-            $rt = new RSTTask();
-            $ref = new ReflectionClass($rt);
-            $method = $ref->getMethod('getToolPath');
-            $method->setAccessible(true);
+        $rt = new RSTTask();
+        $ref = new ReflectionClass($rt);
+        $method = $ref->getMethod('getToolPath');
+        $method->setAccessible(true);
 
-            $this->expectException(BuildException::class);
-            $this->expectExceptionMessage('"rst2doesnotexist" not found. Install python-docutils.');
+        $this->expectException(BuildException::class);
+        $this->expectExceptionMessage('"rst2doesnotexist" not found. Install python-docutils.');
 
-            $method->invoke($rt, 'doesnotexist');
-        } else {
-            $this->markTestSkipped('No ReflectionMethod::setAccessible available.');
-        }
+        $method->invoke($rt, 'doesnotexist');
     }
 
     /**
      * Get the tool path previously set with setToolpath()
+     *
+     * @requires function ReflectionMethod::setAccessible
      */
     public function testGetToolPathCustom()
     {
-        if (method_exists('ReflectionMethod', 'setAccessible')) {
-            $rt = new RSTTask();
-            $rt->setToolpath('true'); //mostly /bin/true on unix
-            $ref = new ReflectionClass($rt);
-            $method = $ref->getMethod('getToolPath');
-            $method->setAccessible(true);
-            $this->assertContains('/true', $method->invoke($rt, 'foo'));
-        } else {
-            $this->markTestSkipped('No ReflectionMethod::setAccessible available.');
-        }
+        $rt = new RSTTask();
+        $rt->setToolpath('true'); //mostly /bin/true on unix
+        $ref = new ReflectionClass($rt);
+        $method = $ref->getMethod('getToolPath');
+        $method->setAccessible(true);
+        $this->assertContains('/true', $method->invoke($rt, 'foo'));
     }
 
     public function testSetToolpathNotExisting()
@@ -126,17 +123,17 @@ class RSTTaskTest extends BuildFileTest
         $rt->setToolpath(__FILE__);
     }
 
+    /**
+     * @throws ReflectionException
+     * @requires function ReflectionMethod::setAccessible
+     */
     public function testGetToolPathHtmlFormat()
     {
-        if (method_exists('ReflectionMethod', 'setAccessible')) {
-            $rt = new RSTTask();
-            $ref = new ReflectionClass($rt);
-            $method = $ref->getMethod('getToolPath');
-            $method->setAccessible(true);
-            $this->assertContains('rst2html', $method->invoke($rt, 'html'));
-        } else {
-            $this->markTestSkipped('No ReflectionMethod::setAccessible available.');
-        }
+        $rt = new RSTTask();
+        $ref = new ReflectionClass($rt);
+        $method = $ref->getMethod('getToolPath');
+        $method->setAccessible(true);
+        $this->assertContains('rst2html', $method->invoke($rt, 'html'));
     }
 
     public function testSingleFileParameterFile()

--- a/test/classes/phing/tasks/system/ApplyTaskTest.php
+++ b/test/classes/phing/tasks/system/ApplyTaskTest.php
@@ -222,45 +222,33 @@ class ApplyTaskTest extends BuildFileTest
 
     /**
      * Tests the dir changing on an existent directory
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testChangeToDir()
     {
-
-        // Validating the OS platform
-        if ($this->windows) {
-            $this->markTestSkipped("Windows does not have 'ls'");
-        }
-
         $this->executeTarget(__FUNCTION__);
         $this->assertInLogs('Working directory change successful');
     }
 
     /**
      * Tests the failonerror/checkreturn value for 'true'
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testCheckreturnTrue()
     {
-
-        // Validating the OS platform
-        if ($this->windows) {
-            $this->markTestSkipped("Windows does not have '/bin/true'");
-        }
-
         $this->executeTarget(__FUNCTION__);
         $this->assertTrue(true);
     }
 
     /**
      * Tests the failonerror/checkreturn value for 'false'
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testCheckreturnFalse()
     {
-
-        // Validating the OS platform
-        if ($this->windows) {
-            $this->markTestSkipped("Windows does not have '/bin/false'");
-        }
-
         return $this->expectBuildExceptionContaining(__FUNCTION__, __FUNCTION__, 'Task exited with code (1)');
     }
 
@@ -325,15 +313,11 @@ class ApplyTaskTest extends BuildFileTest
 
     /**
      * Tests the error file functionality
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testError()
     {
-
-        // Validating the OS platform
-        if ($this->windows) {
-            $this->markTestSkipped("The script is unlikely to run on MS Windows");
-        }
-
         // Getting a temp. file
         $tempfile = tempnam(FileUtils::getTempDir(), 'phing-exectest-');
 
@@ -355,14 +339,11 @@ class ApplyTaskTest extends BuildFileTest
 
     /**
      * Tests the execution with the background process spawning
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testSpawn()
     {
-        // Validating the OS platform
-        if ($this->windows) {
-            $this->markTestSkipped("Windows does not have /bin/sleep");
-        }
-
         // Process
         $start = time();
         $this->executeTarget(__FUNCTION__);
@@ -402,29 +383,22 @@ class ApplyTaskTest extends BuildFileTest
 
     /**
      * Tests the relative source filenames functionality
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testRelativeSourceFilenames()
     {
-        // Validating the OS platform
-        if ($this->windows) {
-            $this->markTestSkipped("Windows does not have 'ls'");
-        }
-
         $this->executeTarget(__FUNCTION__);
         $this->assertNotInLogs('/etc/');
     }
 
     /**
      * Tests the source filename addition functionality
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testSourceFilename()
     {
-
-        // Validating the OS platform
-        if ($this->windows) {
-            $this->markTestSkipped("Windows does not have 'ls'");
-        }
-
         $this->executeTarget(__FUNCTION__);
         // As the addsourcefilename is 'off', only the executable should be processed in the execution
         $this->assertInLogs('Executing command: ls');

--- a/test/classes/phing/tasks/system/AttribTaskTest.php
+++ b/test/classes/phing/tasks/system/AttribTaskTest.php
@@ -23,7 +23,7 @@
  * @author  Siad Ardroumli
  * @package phing.tasks.system
  *
- * @requires OS WIN
+ * @requires OS WIN32|WINNT
  */
 class AttribTaskTest extends BuildFileTest
 {
@@ -43,9 +43,6 @@ class AttribTaskTest extends BuildFileTest
 
     public function testAttrib()
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-            $this->markTestSkipped('Windows only test.');
-        }
         $this->executeTarget(__FUNCTION__);
 
         /** @var Project $project */

--- a/test/classes/phing/tasks/system/ChmodTaskTest.php
+++ b/test/classes/phing/tasks/system/ChmodTaskTest.php
@@ -22,16 +22,13 @@
  *
  * @author  Michiel Rook <mrook@php.net>
  * @package phing.tasks.system
+ *
+ * @requires OS ^(?:(?!Win).)*$
  */
 class ChmodTaskTest extends BuildFileTest
 {
     public function setUp(): void
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-            $this->markTestSkipped("chmod tests don't work on Windows");
-            return;
-        }
-
         $this->configureProject(
             PHING_TEST_BASE . '/etc/tasks/system/ChmodTaskTest.xml'
         );

--- a/test/classes/phing/tasks/system/ChownTaskTest.php
+++ b/test/classes/phing/tasks/system/ChownTaskTest.php
@@ -22,6 +22,8 @@
  *
  * @author  Michiel Rook <mrook@php.net>
  * @package phing.tasks.system
+ *
+ * @requires OS ^(?:(?!Win).)*$
  */
 class ChownTaskTest extends BuildFileTest
 {
@@ -39,10 +41,6 @@ class ChownTaskTest extends BuildFileTest
 
     public function testChangeGroup()
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-            $this->markTestSkipped("chown tests don't work on Windows");
-        }
-
         $userinfo = posix_getpwuid(posix_geteuid());
         $username = $userinfo['name'];
 

--- a/test/classes/phing/tasks/system/ConditionTaskTest.php
+++ b/test/classes/phing/tasks/system/ConditionTaskTest.php
@@ -56,6 +56,9 @@ class ConditionTaskTest extends BuildFileTest
         $this->assertPropertyUnset('ref.exists');
     }
 
+    /**
+     * @requires extension sockets
+     */
     public function testSocketCondition()
     {
         $this->executeTarget(__FUNCTION__);

--- a/test/classes/phing/tasks/system/CopyTaskTest.php
+++ b/test/classes/phing/tasks/system/CopyTaskTest.php
@@ -39,12 +39,11 @@ class CopyTaskTest extends BuildFileTest
         $this->executeTarget("clean");
     }
 
+    /**
+     * @requires OS ^(?:(?!Win).)*$
+     */
     public function testCopyDanglingSymlink()
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-            $this->markTestSkipped("Dangling symlinks don't work on Windows");
-        }
-
         $this->executeTarget("testCopyDanglingSymlink");
         $this->assertInLogs("Copying 1 file to");
     }
@@ -53,13 +52,11 @@ class CopyTaskTest extends BuildFileTest
      * Test for {@link http://www.phing.info/trac/ticket/981}
      * FileUtil::copyFile(): preserveLastModified causes
      * empty symlink target file
+     *
+     * @requires OS ^(?:(?!Win).)*$
      */
     public function testCopySymlinkPreserveLastModifiedShouldCopyTarget()
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-            $this->markTestSkipped("Bug not applicable on Window");
-        }
-
         $this->executeTarget(__FUNCTION__);
         $this->assertInLogs("Copying 2 files to");
         $this->assertGreaterThan(0, $this->project->getProperty('test.filesize'));

--- a/test/classes/phing/tasks/system/DefaultExcludesTest.php
+++ b/test/classes/phing/tasks/system/DefaultExcludesTest.php
@@ -42,6 +42,9 @@ class DefaultExcludesTest extends BuildFileTest
         $this->executeTarget("cleanup-excludes");
     }
 
+    /**
+     * @requires PHPUnit < 8
+     */
     public function test1()
     {
         $expected = [
@@ -80,6 +83,9 @@ class DefaultExcludesTest extends BuildFileTest
         $this->assertArraySubset($expected, DirectoryScanner::getDefaultExcludes());
     }
 
+    /**
+     * @requires PHPUnit < 8
+     */
     public function test2()
     {
         $expected = [
@@ -119,6 +125,9 @@ class DefaultExcludesTest extends BuildFileTest
         $this->assertArraySubset($expected, DirectoryScanner::getDefaultExcludes());
     }
 
+    /**
+     * @requires PHPUnit < 8
+     */
     public function test3()
     {
         $expected = [

--- a/test/classes/phing/tasks/system/DeleteTaskTest.php
+++ b/test/classes/phing/tasks/system/DeleteTaskTest.php
@@ -39,12 +39,11 @@ class DeleteTaskTest extends BuildFileTest
         $this->executeTarget("clean");
     }
 
+    /**
+     * @requires OS ^(?:(?!Win).)*$
+     */
     public function testCopyDanglingSymlink()
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-            $this->markTestSkipped("Dangling symlinks don't work on Windows");
-        }
-
         $this->executeTarget("testDeleteDanglingSymlink");
         $this->assertInLogs("Deleting 1 files from");
     }

--- a/test/classes/phing/tasks/system/ExecTaskTest.php
+++ b/test/classes/phing/tasks/system/ExecTaskTest.php
@@ -248,11 +248,11 @@ class ExecTaskTest extends BuildFileTest
         $this->executeTarget(__FUNCTION__);
     }
 
+    /**
+     * @requires OS ^(?:(?!Win).)*$
+     */
     public function testChangeToDir()
     {
-        if ($this->windows) {
-            $this->markTestSkipped("Windows does not have 'ls'");
-        }
         $this->executeTarget(__FUNCTION__);
         $this->assertInLogs('ExecTaskTest.php');
     }

--- a/test/classes/phing/tasks/system/RelentlessTest.php
+++ b/test/classes/phing/tasks/system/RelentlessTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'phing/BuildFileTest.php';
-
 /**
  * Tests the Relentless Task
  *

--- a/test/classes/phing/tasks/system/XsltTaskTest.php
+++ b/test/classes/phing/tasks/system/XsltTaskTest.php
@@ -22,6 +22,8 @@
  *
  * @author  Siad Ardroumli <siad.ardroumli@gmail.com>
  * @package phing.tasks.system
+ * @requires extension xsl
+ * @requires extension dom
  */
 class XsltTaskTest extends BuildFileTest
 {

--- a/test/classes/phing/types/PearPackageFileSetBuildTest.php
+++ b/test/classes/phing/types/PearPackageFileSetBuildTest.php
@@ -33,10 +33,6 @@ class PearPackageFileSetBuildTest extends BuildFileTest
             $this->markTestSkipped("This test requires PEAR to be installed");
         }
 
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PEAR tests do not run on HHVM");
-        }
-
         //needed for PEAR's Config and Registry classes
         error_reporting(error_reporting() & ~E_DEPRECATED & ~E_STRICT);
 

--- a/test/classes/phing/types/PearPackageFileSetTest.php
+++ b/test/classes/phing/types/PearPackageFileSetTest.php
@@ -33,10 +33,6 @@ class PearPackageFileSetTest extends BuildFileTest
             $this->markTestSkipped("This test requires PEAR to be installed");
         }
 
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PEAR tests do not run on HHVM");
-        }
-
         //needed for PEAR's Config and Registry classes
         error_reporting(error_reporting() & ~E_DEPRECATED & ~E_STRICT);
     }

--- a/test/classes/phing/util/PearPackageScannerTest.php
+++ b/test/classes/phing/util/PearPackageScannerTest.php
@@ -27,16 +27,10 @@
  */
 class PearPackageScannerTest extends BuildFileTest
 {
-    protected $backupGlobals = false;
-
     public function setUp(): void
     {
         if (!class_exists('PEAR_Config')) {
             $this->markTestSkipped("This test requires PEAR to be installed");
-        }
-
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("PEAR tests do not run on HHVM");
         }
 
         //needed for PEAR's Config and Registry classes


### PR DESCRIPTION
This PR wants

- replace checks for extensions, PHP versions or functions with PHPUnits `@require` notations
- remove checks for HHVM because PHP 7 is incompatible with HHVM
- remove SVN like `@version` tag
- remove overwriting variable `$backupGlobals` because this dafault now
- add some `@require` notations based on the errors I got on my windows system