### PR TITLE
[PhingCallTask] set target on callee

### DIFF
--- a/classes/phing/tasks/system/PhingCallTask.php
+++ b/classes/phing/tasks/system/PhingCallTask.php
@@ -121,11 +121,15 @@ class PhingCallTask extends Task
     /**
      * Target to execute, required.
      *
-     * @param $target
+     * @param string $target
      */
-    public function setTarget($target)
+    public function setTarget(string $target): void
     {
-        $this->subTarget = (string) $target;
+        if ($this->callee === null) {
+            $this->init();
+        }
+        $this->callee->setTarget($target);
+        $this->subTarget = $target;
     }
 
     /**


### PR DESCRIPTION
Added missing `setTarget` call on the callee.
Related to #1241 