### PR TITLE
Provide --config-option switch for svn tasks

### DIFF
--- a/classes/phing/tasks/ext/svn/SvnBaseTask.php
+++ b/classes/phing/tasks/ext/svn/SvnBaseTask.php
@@ -53,6 +53,8 @@ abstract class SvnBaseTask extends Task
 
     private $svnSwitches = [];
 
+    protected $configOption = null;
+
     private $toDir = "";
 
     protected $fetchMode;
@@ -281,6 +283,24 @@ abstract class SvnBaseTask extends Task
     }
 
     /**
+     * Sets the config-option switch
+     *
+     * @param $value
+     */
+    public function setConfigOption($value)
+    {
+        $this->configOption = $value;
+    }
+
+    /**
+     * Returns the config-option switch
+     */
+    public function getConfigOption()
+    {
+        return $this->configOption;
+    }
+
+    /**
      * Creates a VersionControl_SVN class based on $mode
      *
      * @param  string The SVN mode to use (info, export, checkout, ...)
@@ -298,6 +318,10 @@ abstract class SvnBaseTask extends Task
             $options['svn_path'] = $this->getSvnPath();
         } else {
             $options['binaryPath'] = $this->getSvnPath();
+        }
+
+        if ($this->configOption) {
+            $options['configOption'] = $this->configOption;
         }
 
         // Pass array of subcommands we need to factory

--- a/docs/guide/en/source/appendixes/optionaltasks.xml
+++ b/docs/guide/en/source/appendixes/optionaltasks.xml
@@ -12081,7 +12081,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12204,7 +12204,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12326,7 +12326,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12444,7 +12444,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12459,7 +12459,8 @@ host="webserver" command="ls" /></programlisting>
    force="true"
    nocache="true"
    repositoryurl="svn://localhost/project/trunk/"
-   todir="/home/user/svnwc"/></programlisting>
+   todir="/home/user/svnwc"
+   configoption="config:miscellany:use-commit-times=yes" /></programlisting>
 
             <programlisting language="xml">&lt;svnexport
    svnpath="C:/Subversion/bin/svn.exe"
@@ -12551,7 +12552,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12648,7 +12649,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12752,7 +12753,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12821,7 +12822,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12903,7 +12904,7 @@ host="webserver" command="ls" /></programlisting>
                     <entry><literal>configOption</literal></entry>
                     <entry><literal role="type">String</literal></entry>
                     <entry>Override subversion's config option</entry>
-                    <entry><literal>false</literal></entry>
+                    <entry><literal>n/a</literal></entry>
                     <entry>No</entry>
                 </row>
             </tbody>
@@ -13004,7 +13005,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -13117,7 +13118,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -13214,7 +13215,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -13314,7 +13315,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -13400,7 +13401,7 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>configOption</literal></entry>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Override subversion's config option</entry>
-                        <entry><literal>false</literal></entry>
+                        <entry><literal>n/a</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>

--- a/docs/guide/en/source/appendixes/optionaltasks.xml
+++ b/docs/guide/en/source/appendixes/optionaltasks.xml
@@ -12077,6 +12077,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -12191,6 +12198,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal role="type">String</literal></entry>
                         <entry>Name of property to set to the last committed revision number</entry>
                         <entry>svn.committedrevision</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -12308,6 +12322,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -12419,6 +12440,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -12519,6 +12547,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry>none</entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -12606,6 +12641,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal role="type">Boolean</literal></entry>
                         <entry>Sets whether to store actual last changed revision of the
                             directory/file mentioned</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
@@ -12706,6 +12748,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -12767,6 +12816,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry>Flag for recursive revert.</entry>
                         <entry>none</entry>
                         <entry>Yes</entry>
+                    </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
                     </row>
                 </tbody>
             </tgroup>
@@ -12841,6 +12897,13 @@ host="webserver" command="ls" /></programlisting>
                     <entry><literal role="type">Integer</literal></entry>
                     <entry>Limits the number of items to get back from the command</entry>
                     <entry>n/a</entry>
+                    <entry>No</entry>
+                </row>
+                <row>
+                    <entry><literal>configOption</literal></entry>
+                    <entry><literal role="type">String</literal></entry>
+                    <entry>Override subversion's config option</entry>
+                    <entry><literal>false</literal></entry>
                     <entry>No</entry>
                 </row>
             </tbody>
@@ -12934,6 +12997,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>trustServerCert</literal></entry>
                         <entry><literal role="type">Boolean</literal></entry>
                         <entry>Trust self-signed certificates</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
@@ -13043,6 +13113,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -13131,6 +13208,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry><literal role="type">Boolean</literal></entry>
                         <entry>Recursive proplist usage?</entry>
                         <entry>false</entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
                         <entry>No</entry>
                     </row>
                 </tbody>
@@ -13226,6 +13310,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry>none</entry>
                         <entry>Yes</entry>
                     </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -13304,6 +13395,13 @@ host="webserver" command="ls" /></programlisting>
                         <entry>The svn property to set</entry>
                         <entry>none</entry>
                         <entry>Yes</entry>
+                    </row>
+                    <row>
+                        <entry><literal>configOption</literal></entry>
+                        <entry><literal role="type">String</literal></entry>
+                        <entry>Override subversion's config option</entry>
+                        <entry><literal>false</literal></entry>
+                        <entry>No</entry>
                     </row>
                 </tbody>
             </tgroup>

--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -6171,6 +6171,9 @@
                         <data type="boolean"/>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
             <empty/>
         </element>
@@ -6217,6 +6220,9 @@
                     <attribute name="trustservercert">
                         <data type="boolean"/>
                     </attribute>
+                </optional>
+                <optional>
+                    <attribute name="configoption" />
                 </optional>
             </interleave>
         </element>
@@ -6270,6 +6276,9 @@
                         <data type="boolean"/>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6316,6 +6325,9 @@
                         <data type="boolean"/>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6345,6 +6357,9 @@
                 <optional>
                     <attribute name="subelement"/>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6370,6 +6385,9 @@
                 </optional>
                 <optional>
                     <attribute name="recursive"/>
+                </optional>
+                <optional>
+                    <attribute name="configoption" />
                 </optional>
             </interleave>
         </element>
@@ -6400,6 +6418,9 @@
                 <optional>
                     <attribute name="fromdir"/>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6426,6 +6447,9 @@
                 <optional>
                     <attribute name="svnpropertyvalue"/>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6449,6 +6473,9 @@
                     <attribute name="lastChanged">
                         <data type="boolean"/>
                     </attribute>
+                </optional>
+                <optional>
+                    <attribute name="configoption" />
                 </optional>
             </interleave>
         </element>
@@ -6483,6 +6510,9 @@
                         <data type="boolean"/>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6509,6 +6539,9 @@
                     <attribute name="limit">
                         <data type="int"/>
                     </attribute>
+                </optional>
+                <optional>
+                    <attribute name="configoption" />
                 </optional>
             </interleave>
         </element>
@@ -6558,6 +6591,9 @@
                         <data type="boolean"/>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6602,6 +6638,9 @@
                         <data type="boolean"/>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>
@@ -6616,6 +6655,9 @@
                 <attribute name="recursive">
                     <data type="boolean"/>
                 </attribute>
+                <optional>
+                    <attribute name="configoption" />
+                </optional>
             </interleave>
         </element>
     </define>

--- a/test/classes/phing/tasks/ext/svn/SvnExportTaskTest.php
+++ b/test/classes/phing/tasks/ext/svn/SvnExportTaskTest.php
@@ -46,4 +46,9 @@ class SvnExportTaskTest extends AbstractSvnTaskTest
             'is not a working copy'
         );
     }
+
+    public function testExportConfigOption()
+    {
+        $this->expectBuildExceptionContaining('exportConfigOption', 'provided --config-option with unreachable http-proxy not used', "Could not resolve proxy server 'non-existed.phing.org'");
+    }
 }

--- a/test/etc/tasks/ext/svn/SvnExportTest.xml
+++ b/test/etc/tasks/ext/svn/SvnExportTest.xml
@@ -20,4 +20,11 @@
         <svnexport todir="${tmp.dir.resolved}" />
     </target>
 
+    <target name="exportConfigOption" description="Export with unreachable http-proxy">
+        <svnexport
+                repositoryurl="${repo.url}"
+                todir="${tmp.dir.resolved}"
+                configOption="servers:global:http-proxy-host=non-existed.phing.org" />
+    </target>
+
 </project>


### PR DESCRIPTION
In some cases i need set _--config-option_ switch for svn commands (ex. _--config-option config:miscellany:use-commit-times=yes_). This PR add configOption property for all svn tasks.