### PR TITLE
[MoveTask] Fixed default overwrite behavior.

### DIFF
--- a/classes/phing/tasks/system/MoveTask.php
+++ b/classes/phing/tasks/system/MoveTask.php
@@ -33,6 +33,12 @@
  */
 class MoveTask extends CopyTask
 {
+    public function __construct()
+    {
+        parent::__construct();
+        $this->overwrite = true;
+    }
+
     /**
      * Validates attributes coming in from XML
      *


### PR DESCRIPTION
As seen in the manual - `overwrite` should be turned on by default.