### PR TITLE
[TruncateTask] fixed unit suffix on length/adjust

### DIFF
--- a/classes/phing/tasks/system/TruncateTask.php
+++ b/classes/phing/tasks/system/TruncateTask.php
@@ -33,40 +33,37 @@ class TruncateTask extends Task
     /**
      * Set a single target File.
      *
-     * @param  PhingFile|string $f the single File
+     * @param  PhingFile $f the single File
      * @throws \IOException
      * @throws \NullPointerException
      */
-    public function setFile($f)
+    public function setFile(PhingFile $f): void
     {
-        if (is_string($f)) {
-            $f = new PhingFile($f);
-        }
         $this->file = $f;
     }
 
     /**
      * Set the amount by which files' lengths should be adjusted.
-     * It is permissible to append K / M / G / T / P.
+     * It is permissible to append k / m / g.
      *
-     * @param $adjust (positive or negative) adjustment amount.
+     * @param string $adjust (positive or negative) adjustment amount.
      */
-    public function setAdjust($adjust)
+    public function setAdjust(string $adjust)
     {
-        $this->adjust = $adjust;
+        $this->adjust = Phing::convertShorthand($adjust);
     }
 
     /**
      * Set the length to which files should be set.
-     * It is permissible to append K / M / G / T / P.
+     * It is permissible to append k / m / g.
      *
-     * @param $length (positive) adjustment amount.
+     * @param string $length (positive) adjustment amount.
      *
      * @throws \BuildException
      */
-    public function setLength($length)
+    public function setLength(string $length)
     {
-        $this->length = $length;
+        $this->length = Phing::convertShorthand($length);
         if ($this->length !== null && $this->length < 0) {
             throw new BuildException('Cannot truncate to length ' . $this->length);
         }

--- a/test/classes/phing/tasks/system/TruncateTaskTest.php
+++ b/test/classes/phing/tasks/system/TruncateTaskTest.php
@@ -52,6 +52,12 @@ class TruncateTaskTest extends BuildFileTest
         $this->assertSame($this->getProject()->getProperty('test.explicit.length'), 1034);
     }
 
+    public function testExplicitUnit()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertSame($this->getProject()->getProperty('test.explicit.unit.length'), 1024);
+    }
+
     public function testExtend()
     {
         $this->executeTarget(__FUNCTION__);

--- a/test/etc/tasks/system/TruncateTaskTest.xml
+++ b/test/etc/tasks/system/TruncateTaskTest.xml
@@ -23,6 +23,7 @@
     <target name="testExplicitUnit">
         <truncate file="${tmp.dir}/foo" length="1k" />
         <filesize file="${tmp.dir}/foo" propertyname="test.explicit.unit.length" />
+    </target>
 
     <target name="testExtend">
         <truncate file="${tmp.dir}/foo" length="5" />

--- a/test/etc/tasks/system/TruncateTaskTest.xml
+++ b/test/etc/tasks/system/TruncateTaskTest.xml
@@ -20,6 +20,10 @@
         <filesize file="${tmp.dir}/foo" propertyname="test.explicit.length" />
     </target>
 
+    <target name="testExplicitUnit">
+        <truncate file="${tmp.dir}/foo" length="1k" />
+        <filesize file="${tmp.dir}/foo" propertyname="test.explicit.unit.length" />
+
     <target name="testExtend">
         <truncate file="${tmp.dir}/foo" length="5" />
         <filesize file="${tmp.dir}/foo" propertyname="test.extend.length" />


### PR DESCRIPTION
Using a unit for length or adjust is not possible.
Something like this was fixed:
```xml
<truncate file="foo" length="1k"/>
```