### PR TITLE
[MoveTask] Added preservepermissions support.

### DIFF
--- a/classes/phing/tasks/system/MoveTask.php
+++ b/classes/phing/tasks/system/MoveTask.php
@@ -91,7 +91,8 @@ class MoveTask extends CopyTask
                             $this->overwrite,
                             $this->preserveLMT,
                             $this->filterChains,
-                            $this->mode
+                            $this->mode,
+                            $this->preservePermissions
                         );
                         $f->delete(true);
                     } else {
@@ -127,7 +128,8 @@ class MoveTask extends CopyTask
                         $this->overwrite,
                         $this->preserveLMT,
                         $this->filterChains,
-                        $this->mode
+                        $this->mode,
+                        $this->preservePermissions
                     );
 
                     $f->delete();


### PR DESCRIPTION
Preserve permissions from copy task was not taken at all i.e.
`<move preservepermissions="false" `... was not possible.