### PR TITLE
[CopyTask] Added granularity support on LMT of src

### DIFF
--- a/classes/phing/tasks/system/CopyTask.php
+++ b/classes/phing/tasks/system/CopyTask.php
@@ -96,10 +96,9 @@ class CopyTask extends Task
     }
 
     /**
-     * Set the number of milliseconds leeway to give before deciding a
+     * Set the number of seconds leeway to give before deciding a
      * target is out of date.
      *
-     * <p>Default is 1 second, or 2 seconds on DOS systems.</p>
      * @param int $granularity the granularity used to decide if a target is out of date.
      */
     public function setGranularity(int $granularity): void

--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -1397,6 +1397,11 @@
                         <data type="boolean"/>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="granularity" a:defaultValue="0">
+                        <data type="int"/>
+                    </attribute>
+                </optional>
             </interleave>
             <zeroOrMore>
                 <choice>

--- a/test/classes/phing/tasks/system/CopyTaskTest.php
+++ b/test/classes/phing/tasks/system/CopyTaskTest.php
@@ -96,6 +96,6 @@ class CopyTaskTest extends BuildFileTest
 
     public function testGranularity()
     {
-        $this->expectLogContaining(__FUNCTION__, 'Copying 1 file to');
+        $this->expectLogContaining(__FUNCTION__, 'Test omitted, Test is up to date');
     }
 }

--- a/test/classes/phing/tasks/system/CopyTaskTest.php
+++ b/test/classes/phing/tasks/system/CopyTaskTest.php
@@ -93,4 +93,9 @@ class CopyTaskTest extends BuildFileTest
         $this->assertInLogs("Copying 1 file to");
         $this->assertEquals("tmp/target-a", readlink(PHING_TEST_BASE . "/etc/tasks/system/tmp/link-b"));
     }
+
+    public function testGranularity()
+    {
+        $this->expectLogContaining(__FUNCTION__, 'Copying 1 file to');
+    }
 }

--- a/test/etc/tasks/system/CopyTaskTest.xml
+++ b/test/etc/tasks/system/CopyTaskTest.xml
@@ -74,9 +74,9 @@
 		<copy file="${tmp.dir}/link-a" tofile="${tmp.dir}/link-b" overwrite="true"/>
 	</target>
 
-	<target name="testGranularity">
-		<touch mkdirs="true" file="${tmp.dir}/copysrcs/Test" datetime="10/10/2000 09:31 AM"/>
-		<touch mkdirs="true" file="${tmp.dir}/copydest/Test" datetime="10/10/1999 09:31 AM"/>
+	<target name="testGranularity" description="do not overwrite existing file without touching  it first">
+		<touch mkdirs="true" file="${tmp.dir}/copysrcs/Test" datetime="-1 day"/>
+		<touch mkdirs="true" file="${tmp.dir}/copydest/Test" datetime="-1 year"/>
 		<copy file="${tmp.dir}/copysrcs/Test" todir="${tmp.dir}/copydest" granularity="999999999" overwrite="false"/>
 	</target>
 

--- a/test/etc/tasks/system/CopyTaskTest.xml
+++ b/test/etc/tasks/system/CopyTaskTest.xml
@@ -77,7 +77,7 @@
 	<target name="testGranularity">
 		<touch mkdirs="true" file="${tmp.dir}/copysrcs/Test" millis="102134111"/>
 		<touch mkdirs="true" file="${tmp.dir}/copydest/Test"/>
-		<copy file="copysrcs/Test" todir="copydest" granularity="999999999"/>
+		<copy file="${tmp.dir}/copysrcs/Test" todir="${tmp.dir}/copydest" granularity="999999999"/>
 	</target>
 
 	<target name="main"/>

--- a/test/etc/tasks/system/CopyTaskTest.xml
+++ b/test/etc/tasks/system/CopyTaskTest.xml
@@ -77,7 +77,7 @@
 	<target name="testGranularity">
 		<touch mkdirs="true" file="${tmp.dir}/copysrcs/Test" datetime="10/10/2000 09:31 AM"/>
 		<touch mkdirs="true" file="${tmp.dir}/copydest/Test" datetime="10/10/1999 09:31 AM"/>
-		<copy file="${tmp.dir}/copysrcs/Test" todir="${tmp.dir}/copydest" granularity="999999999"/>
+		<copy file="${tmp.dir}/copysrcs/Test" todir="${tmp.dir}/copydest" granularity="999999999" overwrite="false"/>
 	</target>
 
 	<target name="main"/>

--- a/test/etc/tasks/system/CopyTaskTest.xml
+++ b/test/etc/tasks/system/CopyTaskTest.xml
@@ -75,8 +75,8 @@
 	</target>
 
 	<target name="testGranularity">
-		<touch mkdirs="true" file="${tmp.dir}/copysrcs/Test" millis="102134111"/>
-		<touch mkdirs="true" file="${tmp.dir}/copydest/Test"/>
+		<touch mkdirs="true" file="${tmp.dir}/copysrcs/Test" datetime="10/10/2000 09:31 AM"/>
+		<touch mkdirs="true" file="${tmp.dir}/copydest/Test" datetime="10/10/1999 09:31 AM"/>
 		<copy file="${tmp.dir}/copysrcs/Test" todir="${tmp.dir}/copydest" granularity="999999999"/>
 	</target>
 

--- a/test/etc/tasks/system/CopyTaskTest.xml
+++ b/test/etc/tasks/system/CopyTaskTest.xml
@@ -74,5 +74,11 @@
 		<copy file="${tmp.dir}/link-a" tofile="${tmp.dir}/link-b" overwrite="true"/>
 	</target>
 
+	<target name="testGranularity">
+		<touch mkdirs="true" file="${tmp.dir}/copysrcs/Test" millis="102134111"/>
+		<touch mkdirs="true" file="${tmp.dir}/copydest/Test"/>
+		<copy file="copysrcs/Test" todir="copydest" granularity="999999999"/>
+	</target>
+
 	<target name="main"/>
 </project>


### PR DESCRIPTION
Get control over the last modified time of the source files. Setting a granularity value will cause the assumption that the source file is x seconds older.