### PR TITLE
[PhingTask] Fixed multi same property

### DIFF
--- a/classes/phing/tasks/system/ForeachTask.php
+++ b/classes/phing/tasks/system/ForeachTask.php
@@ -187,11 +187,9 @@ class ForeachTask extends Task
                     Project::MSG_VERBOSE
                 );
                 $prop = $callee->createProperty();
-                $prop->setOverride(true);
                 $prop->setName($this->param);
                 $prop->setValue($value);
                 $prop = $callee->createProperty();
-                $prop->setOverride(true);
                 $prop->setName($this->index);
                 $prop->setValue($index);
                 $callee->main();

--- a/classes/phing/tasks/system/ForeachTask.php
+++ b/classes/phing/tasks/system/ForeachTask.php
@@ -286,7 +286,6 @@ class ForeachTask extends Task
 
             if ($this->absparam) {
                 $prop = $callee->createProperty();
-                $prop->setOverride(true);
                 $prop->setName($this->absparam);
                 $prop->setValue($fromDir . FileSystem::getFileSystem()->getSeparator() . $value);
             }
@@ -306,7 +305,6 @@ class ForeachTask extends Task
                     Project::MSG_VERBOSE
                 );
                 $prop = $callee->createProperty();
-                $prop->setOverride(true);
                 $prop->setName($this->param);
                 $prop->setValue($value);
             }

--- a/classes/phing/tasks/system/PhingTask.php
+++ b/classes/phing/tasks/system/PhingTask.php
@@ -165,35 +165,35 @@ class PhingTask extends Task
             /**
              * @var PropertyTask $p
              */
-            $p = $this->properties[$i];
-            /**
-             * @var PropertyTask $newP
-             */
-            $newP = $this->newProject->createTask("property");
-            $newP->setName($p->getName());
-            if ($p->getValue() !== null) {
-                $newP->setValue($p->getValue());
-            }
-            if ($p->getFile() !== null) {
-                $newP->setFile($p->getFile());
-            }
-            if ($p->getPrefix() !== null) {
-                $newP->setPrefix($p->getPrefix());
-            }
-            if ($p->getRefid() !== null) {
-                $newP->setRefid($p->getRefid());
-            }
-            if ($p->getEnvironment() !== null) {
-                $newP->setEnvironment($p->getEnvironment());
-            }
-            if ($p->getUserProperty() !== null) {
-                $newP->setUserProperty($p->getUserProperty());
-            }
-            $newP->setOverride($p->getOverride());
-            $newP->setLogoutput($p->getLogoutput());
-            $newP->setQuiet($p->getQuiet());
+            $p = $this->properties[$i] ?? null;
+            if ($p !== null) {
+                /** @var PropertyTask $newP */
+                $newP = $this->newProject->createTask("property");
+                $newP->setName($p->getName());
+                if ($p->getValue() !== null) {
+                    $newP->setValue($p->getValue());
+                }
+                if ($p->getFile() !== null) {
+                    $newP->setFile($p->getFile());
+                }
+                if ($p->getPrefix() !== null) {
+                    $newP->setPrefix($p->getPrefix());
+                }
+                if ($p->getRefid() !== null) {
+                    $newP->setRefid($p->getRefid());
+                }
+                if ($p->getEnvironment() !== null) {
+                    $newP->setEnvironment($p->getEnvironment());
+                }
+                if ($p->getUserProperty() !== null) {
+                    $newP->setUserProperty($p->getUserProperty());
+                }
+                $newP->setOverride($p->getOverride());
+                $newP->setLogoutput($p->getLogoutput());
+                $newP->setQuiet($p->getQuiet());
 
-            $this->properties[$i] = $newP;
+                $this->properties[$i] = $newP;
+            }
         }
     }
 

--- a/classes/phing/tasks/system/PhingTask.php
+++ b/classes/phing/tasks/system/PhingTask.php
@@ -475,8 +475,16 @@ class PhingTask extends Task
     private function overrideProperties()
     {
         // remove duplicate properties - last property wins
-        $this->properties = array_unique(array_reverse($this->properties));
-        foreach ($this->properties as $p) {
+        $properties = array_reverse($this->properties);
+        $set = [];
+        foreach ($properties as $i => $p) {
+            if ($p->getName() !== null && $p->getName() !== '') {
+                if (in_array($p->getName(), $set)) {
+                    unset($this->properties[$i]);
+                } else {
+                    $set[] = $p->getName();
+                }
+            }
             $p->setProject($this->newProject);
             $p->main();
         }

--- a/classes/phing/tasks/system/PhingTask.php
+++ b/classes/phing/tasks/system/PhingTask.php
@@ -474,8 +474,9 @@ class PhingTask extends Task
      */
     private function overrideProperties()
     {
-        foreach (array_keys($this->properties) as $i) {
-            $p = $this->properties[$i];
+        // remove duplicate properties - last property wins
+        $this->properties = array_unique(array_reverse($this->properties));
+        foreach ($this->properties as $p) {
             $p->setProject($this->newProject);
             $p->main();
         }

--- a/test/classes/phing/tasks/condition/PhingTaskTest.php
+++ b/test/classes/phing/tasks/condition/PhingTaskTest.php
@@ -340,6 +340,11 @@ class PhingTaskTest extends BuildFileTest
         $this->expectLogContaining('test-property-override-no-inheritall-start', 'The value of test is 4');
     }
 
+    public function testMultiSameProperty(): void
+    {
+        $this->expectLogContaining('multi-same-property', 'prop is two');
+    }
+
     public function testTopLevelTarget(): void
     {
         $this->expectLogContaining('topleveltarget', 'Hello world');


### PR DESCRIPTION
Fixed following behavior:
```xml
    <target name="multi-same-property">
        <phing phingfile="phing.xml" target="echo-for-multi-same">
            <property name="prop" value="one"/>
            <property name="prop" value="two"/>
        </phing>
    </target>

    <target name="echo-for-multi-same">
        <echo>prop is ${prop}</echo>
    </target>
```
will output:
```
prop is one
prop is one
```
Related to #1241 