### PR TITLE
Added ClassConstants filter

### DIFF
--- a/classes/phing/filters/ClassConstants.php
+++ b/classes/phing/filters/ClassConstants.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+/**
+ * Assembles the constants declared in a PHP class in
+ * <code>key1=value1(PHP_EOL)key2=value2</code>
+ * format.
+ *
+ * @author Siad Ardroumli <siad.ardroumli@gmail.com>
+ * @package phing.filters
+ */
+class ClassConstants extends BaseFilterReader implements ChainableReader
+{
+    private $test = '';
+
+    /**
+     * Returns the filtered stream.
+     *
+     * @param int $len
+     * @return mixed the filtered stream, or -1 if the end of the resulting stream has been reached.
+     *
+     * @throws IOException if the underlying stream throws an IOException
+     * during reading
+     */
+    public function read($len = null)
+    {
+        $buffer = $this->in->read();
+
+        if ($buffer === -1) {
+            return -1;
+        }
+
+        $classes = get_declared_classes();
+        eval($buffer);
+        $newClasses = array_diff(get_declared_classes(), $classes);
+
+        $sb = '';
+        foreach ($newClasses as $name) {
+            $clazz = new ReflectionClass($name);
+            foreach ($clazz->getConstants() as $key => $value) {
+                $sb .= $key . '=' . $value . PHP_EOL;
+            }
+        }
+
+        return $sb;
+    }
+
+    /**
+     * Creates a new ExpandProperties filter using the passed in
+     * Reader for instantiation.
+     *
+     * @param Reader $reader A Reader object providing the underlying stream.
+     *               Must not be <code>null</code>.
+     *
+     * @return ExpandProperties A new filter based on this configuration, but filtering
+     *                the specified reader
+     */
+    public function chain(Reader $reader): Reader
+    {
+        return new self($reader);
+    }
+}

--- a/classes/phing/tasks/system/PropertyTask.php
+++ b/classes/phing/tasks/system/PropertyTask.php
@@ -471,6 +471,11 @@ class PropertyTask extends Task
      */
     protected function addProperty($name, $value)
     {
+        if ($this->file === null && count($this->filterChains) > 0) {
+            $in = FileUtils::getChainedReader(new StringReader($value), $this->filterChains, $this->project);
+            $value = $in->read();
+        }
+
         $ph = PropertyHelper::getPropertyHelper($this->getProject());
         if ($this->userProperty) {
             if ($ph->getUserProperty(null, $name) === null || $this->override) {

--- a/classes/phing/types/FilterChain.php
+++ b/classes/phing/types/FilterChain.php
@@ -248,6 +248,14 @@ class FilterChain extends DataType
         $this->add($o);
     }
 
+    /**
+     * @param ClassConstants $o
+     */
+    public function addClassConstants(ClassConstants $o)
+    {
+        $this->add($o);
+    }
+
     private function add(BaseFilterReader $o)
     {
         $o->setProject($this->project);

--- a/test/classes/phing/filters/ClassConstantsTest.php
+++ b/test/classes/phing/filters/ClassConstantsTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+/**
+ * @author  Siad A6rdroumli <siad.ardroumli@gmail.com>
+ * @package phing.filters
+ */
+class ClassConstantsTest extends BuildFileTest
+{
+    public function setUp(): void
+    {
+        $this->configureProject(PHING_TEST_BASE . "/etc/filters/classconstants.xml");
+    }
+
+    public function tearDown(): void
+    {
+        $this->executeTarget("cleanup");
+    }
+
+    public function testClassConstants()
+    {
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertInLogs('Setting project property: CONST1 -> CONST 1', Project::MSG_DEBUG);
+        $this->assertInLogs('Setting project property: CONST2 -> CONST 2', Project::MSG_DEBUG);
+        $this->assertInLogs('Setting project property: CONST3 -> CONST 3', Project::MSG_DEBUG);
+    }
+}

--- a/test/etc/filters/classconstants.xml
+++ b/test/etc/filters/classconstants.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ~
+  ~ This software consists of voluntary contributions made by many individuals
+  ~ and is licensed under the LGPL. For more information please see
+  ~ <http://phing.info>.
+  -->
+
+<project name="classconstants" default="cleanup">
+    <target name="init">
+        <mkdir dir="result" />
+    </target>
+    <target name="cleanup">
+        <delete dir="result"/>
+    </target>
+    <target name="testClassConstants" depends="init">
+        <property file="constants.php">
+            <filterchain>
+                <classconstants />
+            </filterchain>
+        </property>
+    </target>
+</project>

--- a/test/etc/filters/constants.php
+++ b/test/etc/filters/constants.php
@@ -1,0 +1,6 @@
+class PropFromConst
+{
+    public const CONST1 = 'CONST 1';
+    protected const CONST2 = 'CONST 2';
+    private const CONST3 = 'CONST 3';
+}


### PR DESCRIPTION
Assembles the constants declared in a PHP class in
 ```
key1=value1
key2=value2
```
format.
Example usage:
```php
class Foo
{
    public const CONST1 = 'CONST 1';
    protected const CONST2 = 'CONST 2';
    private const CONST3 = 'CONST 3';
}
```
```xml
<property file="constants.php">
    <filterchain>
      <classconstants />
    </filterchain>
</property>
<echo msg"${CONST1}"/>
<echo msg"${CONST2}"/>
<echo msg"${CONST3}"/>
```
