### PR TITLE
Variable properties which could not expanded should be null.

### DIFF
--- a/classes/phing/PropertyHelper.php
+++ b/classes/phing/PropertyHelper.php
@@ -428,6 +428,9 @@ class PropertyHelper
         if (false !== strpos($found, '${')) {
             // attempt to resolve properties
             $found = $this->replaceProperties($found, null);
+            if (StringHelper::startsWith('${', $found) && StringHelper::endsWith('}', $found)) {
+                $found = null;
+            }
             // save resolved value
             $this->properties[$name] = $found;
         }

--- a/classes/phing/tasks/ext/HttpGetTask.php
+++ b/classes/phing/tasks/ext/HttpGetTask.php
@@ -191,6 +191,11 @@ class HttpGetTask extends HttpTask
         $this->quiet = $v;
     }
 
+    /**
+     * @param string $msg
+     * @param int $msgLevel
+     * @param Exception|null $t
+     */
     public function log($msg, $msgLevel = Project::MSG_INFO, Exception $t = null)
     {
         if (!$this->quiet || $msgLevel <= Project::MSG_ERR) {

--- a/classes/phing/tasks/ext/HttpGetTask.php
+++ b/classes/phing/tasks/ext/HttpGetTask.php
@@ -136,7 +136,7 @@ class HttpGetTask extends HttpTask
      *
      * @param string $filename
      */
-    public function setFilename($filename)
+    public function setFilename($filename): void
     {
         $this->filename = $filename;
     }
@@ -146,7 +146,7 @@ class HttpGetTask extends HttpTask
      *
      * @param string $dir
      */
-    public function setDir($dir)
+    public function setDir($dir): void
     {
         $this->dir = $dir;
     }
@@ -156,7 +156,7 @@ class HttpGetTask extends HttpTask
      *
      * @param bool $value
      */
-    public function setSslVerifyPeer($value)
+    public function setSslVerifyPeer($value): void
     {
         $this->sslVerifyPeer = $value;
     }
@@ -166,7 +166,7 @@ class HttpGetTask extends HttpTask
      *
      * @param bool $value
      */
-    public function setFollowRedirects($value)
+    public function setFollowRedirects($value): void
     {
         $this->followRedirects = $value;
     }
@@ -176,7 +176,7 @@ class HttpGetTask extends HttpTask
      *
      * @param string $proxy
      */
-    public function setProxy($proxy)
+    public function setProxy($proxy): void
     {
         $this->proxy = $proxy;
     }
@@ -186,7 +186,7 @@ class HttpGetTask extends HttpTask
      *
      * @param boolean $v if "true" then be quiet
      */
-    public function setQuiet($v)
+    public function setQuiet($v): void
     {
         $this->quiet = $v;
     }

--- a/classes/phing/tasks/ext/HttpGetTask.php
+++ b/classes/phing/tasks/ext/HttpGetTask.php
@@ -32,14 +32,14 @@ class HttpGetTask extends HttpTask
      *
      * @var string
      */
-    protected $filename = null;
+    protected $filename;
 
     /**
      * Holds the save location
      *
      * @var string
      */
-    protected $dir = null;
+    protected $dir;
 
     /**
      * Holds value for "ssl_verify_peer" option
@@ -53,14 +53,14 @@ class HttpGetTask extends HttpTask
      *
      * @var null|bool
      */
-    protected $followRedirects = null;
+    protected $followRedirects;
 
     /**
      * Holds the proxy
      *
      * @var string
      */
-    protected $proxy = null;
+    protected $proxy;
 
     private $quiet = false;
 
@@ -74,13 +74,12 @@ class HttpGetTask extends HttpTask
             throw new BuildException("Required attribute 'dir' is missing", $this->getLocation());
         }
 
-        $options = [
-            'verify' => $this->sslVerifyPeer
-        ];
+        $options['verify'] = $this->sslVerifyPeer;
+
         if (isset($this->proxy)) {
             $options['proxy'] = $this->proxy;
         }
-        if (null !== $this->followRedirects) {
+        if ($this->followRedirects !== null) {
             $options['allow_redirects'] = $this->followRedirects;
         }
 

--- a/classes/phing/tasks/ext/HttpTask.php
+++ b/classes/phing/tasks/ext/HttpTask.php
@@ -151,7 +151,7 @@ abstract class HttpTask extends Task
 
         foreach (array_keys($this->getProject()->getProperties()) as $propName) {
             if (0 === strpos($propName, 'phing.http.')) {
-                $options[substr($propName, 11)] = $this->getProject()->getProperty($propName);
+                $options[substr($propName, 11)] = (string) $this->getProject()->getProperty($propName);
             }
         }
 

--- a/test/classes/phing/tasks/ext/HTTP/HttpGetTaskTest.php
+++ b/test/classes/phing/tasks/ext/HTTP/HttpGetTaskTest.php
@@ -142,4 +142,22 @@ class HttpGetTaskTest extends BaseHttpTaskTest
         $this->assertEquals($options['proxy'], $this->traces[0]['options']['proxy']);
         $this->assertEquals($options['timeout'], $this->traces[0]['options']['timeout']);
     }
+
+    public function testConfigurationViaEmptyProperty()
+    {
+        $this->createMockHandler([new Response(404, [], '')]);
+
+        try {
+            $this->executeTarget('config-properties-empty');
+        } catch (BuildException $e) {
+        }
+
+        $options = [
+            'proxy' => null,
+            'timeout' => 20
+        ];
+
+        $this->assertEquals($options['proxy'], $this->traces[0]['options']['proxy']);
+        $this->assertEquals($options['timeout'], $this->traces[0]['options']['timeout']);
+    }
 }

--- a/test/etc/tasks/ext/http/httpget.xml
+++ b/test/etc/tasks/ext/http/httpget.xml
@@ -52,4 +52,10 @@
         <property name="phing.http.timeout" value="20" />
         <httpget url="http://example.com/foo.bar" dir="${tmp.dir}"/>
     </target>
+
+    <target name="config-properties-empty">
+        <property name="phing.http.proxy" value="${does.not.exist}" />
+        <property name="phing.http.timeout" value="20" />
+        <httpget url="http://example.com/foo.bar" dir="${tmp.dir}"/>
+    </target>
 </project>


### PR DESCRIPTION
After we discovered that we have an expandable variable, we give it back unchecked. We should return null in case of having a not expandable property.

Fixes #1391 