### PR TITLE
SonarConfigurationFileParser tests fail on cygwin (Windows)

### DIFF
--- a/classes/phing/tasks/ext/sonar/SonarConfigurationFileParser.php
+++ b/classes/phing/tasks/ext/sonar/SonarConfigurationFileParser.php
@@ -89,7 +89,7 @@ class SonarConfigurationFileParser
             throw new BuildException($message);
         }
 
-        $lines = explode("\n", $contents);
+        $lines = preg_split ("/\r?\n/", $contents);
         $count = count($lines);
         $isMultiLine = false;
         for ($i = 0; $i < $count; $i++) {

--- a/classes/phing/tasks/ext/sonar/SonarConfigurationFileParser.php
+++ b/classes/phing/tasks/ext/sonar/SonarConfigurationFileParser.php
@@ -89,7 +89,7 @@ class SonarConfigurationFileParser
             throw new BuildException($message);
         }
 
-        $lines = preg_split ("/\r?\n/", $contents);
+        $lines = preg_split("/\r?\n/", $contents);
         $count = count($lines);
         $isMultiLine = false;
         for ($i = 0; $i < $count; $i++) {

--- a/test/classes/phing/tasks/ext/sonar/SonarConfigurationFileParserTest.php
+++ b/test/classes/phing/tasks/ext/sonar/SonarConfigurationFileParserTest.php
@@ -181,8 +181,8 @@ class SonarConfigurationFileParserTest extends BuildFileTest
 
         $fh = fopen($tmpFile, 'w');
 
-        if (FALSE !== $fh) {
-            register_shutdown_function(function() use($tmpFile) {
+        if (false !== $fh) {
+            register_shutdown_function(function () use ($tmpFile) {
                 unlink($tmpFile);
             });
 
@@ -198,8 +198,7 @@ class SonarConfigurationFileParserTest extends BuildFileTest
 
             $this->assertArrayHasKey('brown', $properties);
             $this->assertContains('cow', $properties);
-        }
-        else {
+        } else {
             $this->fail('Failed to create temporary file');
         }
     }
@@ -214,9 +213,8 @@ class SonarConfigurationFileParserTest extends BuildFileTest
         $tmpFile = tempnam(sys_get_temp_dir(), 'cfp');
 
         $fh = fopen($tmpFile, 'w');
-
-        if (FALSE !== $fh) {
-            register_shutdown_function(function() use($tmpFile) {
+        if (false !== $fh) {
+            register_shutdown_function(function () use ($tmpFile) {
                 unlink($tmpFile);
             });
 
@@ -232,8 +230,7 @@ class SonarConfigurationFileParserTest extends BuildFileTest
 
             $this->assertArrayHasKey('house', $properties);
             $this->assertContains('cat', $properties);
-        }
-        else {
+        } else {
             $this->fail('Failed to create temporary file');
         }
     }

--- a/test/classes/phing/tasks/ext/sonar/SonarConfigurationFileParserTest.php
+++ b/test/classes/phing/tasks/ext/sonar/SonarConfigurationFileParserTest.php
@@ -169,4 +169,72 @@ class SonarConfigurationFileParserTest extends BuildFileTest
         $this->assertArrayHasKey('foo', $properties);
         $this->assertContains('This is a multi-line comment.', $properties);
     }
+
+    /*
+     * Tests property file with Newline(LF) line termination
+     *
+     * @covers SonarConfigurationFileParser::parse
+     */
+    public function testFileWithNL()
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'cfp');
+
+        $fh = fopen($tmpFile, 'w');
+
+        if (FALSE !== $fh) {
+            register_shutdown_function(function() use($tmpFile) {
+                unlink($tmpFile);
+            });
+
+            fwrite($fh, "foo:bar\nbrown:cow\n");
+            fclose($fh);
+
+            $parser = new SonarConfigurationFileParser($tmpFile, $this->getProject());
+
+            $properties = $parser->parse();
+
+            $this->assertArrayHasKey('foo', $properties);
+            $this->assertContains('bar', $properties);
+
+            $this->assertArrayHasKey('brown', $properties);
+            $this->assertContains('cow', $properties);
+        }
+        else {
+            $this->fail('Failed to create temporary file');
+        }
+    }
+
+    /*
+     * Tests property file with CarriageReturn/LineFeed (CRLF) line termination
+     *
+     * @covers SonarConfigurationFileParser::parse
+     */
+    public function testFileWithCRLF()
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'cfp');
+
+        $fh = fopen($tmpFile, 'w');
+
+        if (FALSE !== $fh) {
+            register_shutdown_function(function() use($tmpFile) {
+                unlink($tmpFile);
+            });
+
+            fwrite($fh, "rag:doll\r\nhouse:cat\r\n");
+            fclose($fh);
+
+            $parser = new SonarConfigurationFileParser($tmpFile, $this->getProject());
+
+            $properties = $parser->parse();
+
+            $this->assertArrayHasKey('rag', $properties);
+            $this->assertContains('doll', $properties);
+
+            $this->assertArrayHasKey('house', $properties);
+            $this->assertContains('cat', $properties);
+        }
+        else {
+            $this->fail('Failed to create temporary file');
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1424

Use preg_split ("/\r?\n/", $contents) instead of expand ("\n", $contents) to
account for files which use CRLF or LF (aka newline) as the line
termination character.

Previous failures on Windows:
[phpunit] Testsuite: SonarConfigurationFileParserTest
[phpunit] Tests run: 13, Warnings: 1, Failures: 7, Errors: 0, Incomplete: 0, Skipped: 0, Time elapsed: 0.37023 s
[phpunit] testPropertyWithColonAndWithoutWhitespace FAILED
[phpunit] Failed asserting that an array contains 'bar'.
[phpunit] testPropertyWithColonAndWithWhitespace FAILED
[phpunit] Failed asserting that an array contains 'bar'.
[phpunit] testPropertyWithEqualsSignAndWithoutWhitespace FAILED
[phpunit] Failed asserting that an array contains 'bar'.
[phpunit] testPropertyWithEqualsSignAndWithWhitespace FAILED
[phpunit] Failed asserting that an array contains 'bar'.
[phpunit] testPropertyHasMultiLineValue FAILED
[phpunit] Failed asserting that an array contains 'This is a multi-line comment.'.
[phpunit] testPropertyEndsWithABackSlash FAILED
[phpunit] Failed asserting that an array contains 'This is not a multi-line property, but ends with a backslash\'.
[phpunit] testPropertyHasMultiLineValueIntermediateLineIsEmpty FAILED
[phpunit] Failed asserting that an array contains 'This is a multi-line comment.'.
