### PR TITLE
[CoverageMergerTask] Fixed code coverage handling

### DIFF
--- a/classes/phing/tasks/ext/phpunit/PHPUnitTestRunner8.php
+++ b/classes/phing/tasks/ext/phpunit/PHPUnitTestRunner8.php
@@ -137,10 +137,10 @@ class PHPUnitTestRunner8 implements \PHPUnit\Runner\TestHook, \PHPUnit\Framework
             $whitelist = \Phing\Tasks\Ext\Coverage\CoverageMerger::getWhiteList($this->project);
             $filter = $this->codecoverage->filter();
 
-            if (method_exists($filter, 'includeFiles')) {
-                $filter->includeFiles($whitelist);
-            } else if (method_exists($filter, 'addFilesToWhiteList')) {
+            if (method_exists($filter, 'addFilesToWhiteList')) {
                 $filter->addFilesToWhiteList($whitelist);
+            } elseif (method_exists($filter, 'includeFiles')) {
+                $filter->includeFiles($whitelist);
             }
 
             $res->setCodeCoverage($this->codecoverage);

--- a/composer.lock
+++ b/composer.lock
@@ -165,12 +165,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phingofficial/task-coverage.git",
-                "reference": "3422daf2ab05b59706969e9ed594eda76b8beaf8"
+                "reference": "49e65532a5e2b89650a09c057d9e01b007e47fae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phingofficial/task-coverage/zipball/3422daf2ab05b59706969e9ed594eda76b8beaf8",
-                "reference": "3422daf2ab05b59706969e9ed594eda76b8beaf8",
+                "url": "https://api.github.com/repos/phingofficial/task-coverage/zipball/49e65532a5e2b89650a09c057d9e01b007e47fae",
+                "reference": "49e65532a5e2b89650a09c057d9e01b007e47fae",
                 "shasum": ""
             },
             "require": {
@@ -204,7 +204,7 @@
                 }
             ],
             "description": "coverage database tasks which can be used to gather code coverage information for unit tests.",
-            "time": "2020-11-10T21:30:47+00:00"
+            "time": "2020-11-15T10:33:15+00:00"
         },
         {
             "name": "phing/task-ftpdeploy",
@@ -1659,16 +1659,16 @@
     "packages-dev": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.159.1",
+            "version": "3.161.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "41d8908c1ac53afc8b5dc68aab7a67765e366e15"
+                "reference": "4c1852e9efaef18e15f2a6c914d8dc41fda2a052"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/41d8908c1ac53afc8b5dc68aab7a67765e366e15",
-                "reference": "41d8908c1ac53afc8b5dc68aab7a67765e366e15",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4c1852e9efaef18e15f2a6c914d8dc41fda2a052",
+                "reference": "4c1852e9efaef18e15f2a6c914d8dc41fda2a052",
                 "shasum": ""
             },
             "require": {
@@ -1740,20 +1740,20 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2020-11-10T19:11:53+00:00"
+            "time": "2020-11-13T19:17:55+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.4",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba"
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6e076a124f7ee146f2487554a94b6a19a74887ba",
-                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
                 "shasum": ""
             },
             "require": {
@@ -1798,7 +1798,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:39:10+00:00"
+            "time": "2020-11-13T08:04:11+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2328,16 +2328,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -2378,7 +2378,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/test/classes/phing/tasks/ext/CoverageMergeTest.php
+++ b/test/classes/phing/tasks/ext/CoverageMergeTest.php
@@ -48,6 +48,7 @@ class CoverageMergeTest extends BuildFileTest
         $this->assertFileExists($workspace . '/test-results1.xml');
         $this->assertFileExists($workspace . '/test-results2.xml');
         $this->assertFileExists($workspace . '/test-results3.xml');
+        $this->assertStringNotContainsString('"coverage";a:0:{}', file_get_contents($workspace . '/test.db'));
         $this->assertStringContainsString('Dummy1Test.php', file_get_contents($workspace . '/test.db'));
         $this->assertStringContainsString('Dummy2Test.php', file_get_contents($workspace . '/test.db'));
         $this->assertStringContainsString('Dummy3Test.php', file_get_contents($workspace . '/test.db'));


### PR DESCRIPTION
Fixed code coverage in CoverageMerger Task and fixed wrong test assertion to cover empty db entries.
Related to #1430 and https://github.com/phingofficial/task-coverage/pull/2