### PR TITLE
Change TouchTask and DateSelector to use seconds

### DIFF
--- a/test/build.xml
+++ b/test/build.xml
@@ -59,11 +59,6 @@
                 <coverage-setup database="reports/coverage.db">
                     <fileset dir="${phing.classes.dir.resolved}">
                         <include name="**/*.php"/>
-                        <!-- exclude these to prevent fatals when running on phpunit 6 (the default) -->
-                        <exclude name="**/phpunit/PHPUnitTestRunner.php"/>
-                        <exclude name="**/phpunit/PHPUnitTestRunner6.php"/>
-                        <exclude name="**/phpunit/formatter5/*.php"/>
-                        <exclude name="**/phpunit/formatter6/*.php"/>
                         <exclude name="**/phpcs/*.php"/>
                     </fileset>
                 </coverage-setup>

--- a/test/classes/phing/BuildFileTest.php
+++ b/test/classes/phing/BuildFileTest.php
@@ -255,13 +255,19 @@ abstract class BuildFileTest extends TestCase
     {
         $this->logBuffer = [];
         $this->fullLogBuffer = "";
-        $this->project = new Project();
-        $this->project->init();
+
         $f = new PhingFile($filename);
-        $this->project->setUserProperty("phing.file", $f->getAbsolutePath());
-        $this->project->setUserProperty("phing.dir", dirname($f->getAbsolutePath()));
-        $this->project->addBuildListener(new PhingTestListener($this));
-        ProjectConfigurator::configureProject($this->project, new PhingFile($filename));
+        $absPath = $f->getAbsolutePath();
+
+        $project = new Project();
+        $project->init();
+        $project->setUserProperty("phing.file", $absPath);
+        $project->setUserProperty("phing.dir", dirname($absPath));
+        $project->addBuildListener(new PhingTestListener($this));
+
+        ProjectConfigurator::configureProject($project, $f);
+
+        $this->project = $project;
     }
 
     /**

--- a/test/classes/phing/tasks/system/TouchTaskTest.php
+++ b/test/classes/phing/tasks/system/TouchTaskTest.php
@@ -106,4 +106,28 @@ class TouchTaskTest extends BuildFileTest
         $tmpDir = $this->getProject()->getProperty('tmp.dir');
         $this->assertFileExists($tmpDir . '/touchtest');
     }
+
+    /**
+     * test millis attribute
+     */
+    public function testMillis()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $testFile = $this->getProject()->getProperty('tmp.dir') . '/millis-file';
+        $this->assertFileExists($testFile);
+
+        $this->assertEquals('December 31 1999 23:59:59', date("F d Y H:i:s", filemtime($testFile)));
+    }
+
+    /**
+     * test seconds attribute
+     */
+    public function testSeconds()
+    {
+        $this->executeTarget(__FUNCTION__);
+        $testFile = $this->getProject()->getProperty('tmp.dir') . '/seconds-file';
+        $this->assertFileExists($testFile);
+
+        $this->assertEquals('December 31 1999 23:59:59', date("F d Y H:i:s", filemtime($testFile)));
+    }
 }

--- a/test/classes/phing/tasks/system/TstampTaskTest.php
+++ b/test/classes/phing/tasks/system/TstampTaskTest.php
@@ -25,17 +25,11 @@
  */
 class TstampTaskTest extends BuildFileTest
 {
-    /** @var TstampTask */
-    private $tstamp;
-
     public function setUp(): void
     {
         $this->configureProject(
             PHING_TEST_BASE . '/etc/tasks/system/TstampTest.xml'
         );
-
-        $this->tstamp = new TstampTask();
-        $this->tstamp->setProject($this->project);
     }
 
     public function testMagicProperty()
@@ -64,8 +58,10 @@ class TstampTaskTest extends BuildFileTest
 
     public function testPrefix()
     {
-        $this->tstamp->setPrefix('prefix');
-        $this->tstamp->main();
+        $tstamp = new TstampTask();
+        $tstamp->setProject($this->project);
+        $tstamp->setPrefix('prefix');
+        $tstamp->main();
         $prop = $this->project->getProperty('prefix.DSTAMP');
         $this->assertNotNull($prop);
     }

--- a/test/classes/phing/types/selectors/DateSelectorTest.php
+++ b/test/classes/phing/types/selectors/DateSelectorTest.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+
+/**
+ * Class SelectorUtilsTest
+ *
+ * Test cases for SelectorUtils
+ */
+class DateSelectorTest extends BuildFileTest
+{
+    const TWENTY_FOUR_HOURS_IN_SECONDS = (24 * 60 * 60);
+
+    private $inputDir;
+    private $outputDir;
+
+    public function setUp(): void
+    {
+        $this->configureProject(
+            PHING_TEST_BASE . '/etc/types/selectors/DateSelectorTest.xml'
+        );
+        $this->executeTarget('setup');
+
+        $project = $this->getProject();
+        $this->inputDir = $project->getProperty('input.dir');
+        $this->outputDir = rtrim($project->getProperty('output.dir'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+
+    public function tearDown(): void
+    {
+        $this->executeTarget('clean');
+    }
+
+    /**
+     * Creates a test file in the specified directory with the specified
+     * creation time.
+     *
+     * @param string $dir The directory where the test file should be created.
+     * @param int $timestamp The timestamp to touch the file with (in seconds
+     *              since the epoch).
+     *
+     * @return string The fully qualified name of the test file.
+     */
+    private function createTestFile(string $dir, int $timestamp): string
+    {
+        $file = tempnam($dir, 'dst');
+        $writeCnt = file_put_contents($file, 'DateSelectorTest file');
+        if (false !== $writeCnt) {
+            touch($file, $timestamp);
+        } else {
+            $this->fail('Unable to create test file: ' . $file);
+        }
+
+        return $file;
+    }
+
+    /*
+     * Test using seconds attribute
+     *
+     * when defaults to equal
+     * granularity defaults to 0
+     */
+    public function testSecondsWithDefaults()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile));
+        $this->assertFileExists($this->outputDir . basename($nowFile));
+    }
+
+    /*
+     * Test using seconds attribute with when set to after
+     *
+     * granularity defaults to 0
+     */
+    public function testSecondsWithWhenAfter()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile));
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile));
+        $this->assertFileExists($this->outputDir . basename($afterFile));
+    }
+
+    /*
+     * Test using seconds attribute with when set to before
+     *
+     * granularity defaults to 0
+     */
+    public function testSecondsWithWhenBefore()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile));
+        $this->assertFileExists($this->outputDir . basename($beforeFile));
+    }
+
+    /*
+     * Test using seconds attribute with granularity at 60
+     *
+     * when defaults to equal
+     */
+    public function testSecondsGranularitySixtySeconds()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $inWindowFiles = array(
+            $this->createTestFile($this->inputDir, $epochSeconds - 60),
+            $this->createTestFile($this->inputDir, $epochSeconds - 59),
+            $this->createTestFile($this->inputDir, $epochSeconds - 30),
+            $this->createTestFile($this->inputDir, $epochSeconds),
+            $this->createTestFile($this->inputDir, $epochSeconds + 30),
+            $this->createTestFile($this->inputDir, $epochSeconds + 59),
+            $this->createTestFile($this->inputDir, $epochSeconds + 60)
+        );
+
+        $outOfWindowFiles = array(
+            $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS),
+            $this->createTestFile($this->inputDir, $epochSeconds - 61),
+            $this->createTestFile($this->inputDir, $epochSeconds + 61),
+            $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS)
+        );
+
+        $this->executeTarget(__FUNCTION__);
+
+        foreach ($inWindowFiles as $file) {
+            $this->assertFileExists($this->outputDir . basename($file));
+        }
+
+        foreach ($outOfWindowFiles as $file) {
+            $this->assertFileDoesNotExist($this->outputDir . basename($file));
+        }
+    }
+
+    /*
+     * Test using millis attribute
+     *
+     * when defaults to equal
+     * granularity defaults to 0
+     */
+    public function testMillis()
+    {
+        $epochSeconds = time();
+        $epochMillis = $epochSeconds * 1000;
+
+        $this->getProject()->setProperty('epoch.millis', $epochMillis);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - 60);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + 60);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile));
+        $this->assertFileExists($this->outputDir . basename($nowFile));
+    }
+
+    /*
+     * Test using an invalid when value
+     */
+    public function testInvalidWhen()
+    {
+        $this->expectBuildException(__FUNCTION__, 'when attribute has invalid value');
+    }
+
+    /*
+     * Test using an invalid when value
+     */
+    public function testInvalidAttribute()
+    {
+        $this->expectBuildException(__FUNCTION__, 'invalid attribut for task');
+    }
+}

--- a/test/etc/tasks/system/TouchTaskTest.xml
+++ b/test/etc/tasks/system/TouchTaskTest.xml
@@ -2,10 +2,12 @@
 <project name="TouchTaskTest" default="main">
     <property name="tmp.dir" value="tmp"/>
 
-    <tstamp />
+    <tstamp>
+        <format property="formattedTimestamp" pattern="%m/%d/%Y %I:%M %p" /> <!-- MM/DD/YYYY HH:MM AM or PM /> -->
+    </tstamp>
 
     <selector id="map.selector">
-        <date datetime="${DSTAMP}:${TSTAMP}" />
+        <date datetime="${formattedTimestamp}" />
     </selector>
 
     <target name="setup">
@@ -29,19 +31,19 @@
     </target>
 
     <target name="testFilelist">
-        <touch datetime="${DSTAMP}:${TSTAMP}">
+        <touch datetime="${formattedTimestamp}">
             <filelist dir="${tmp.dir}" files="simple-file"/>
         </touch>
     </target>
 
     <target name="testFileset" depends="testSimpleTouch">
-        <touch datetime="${DSTAMP}:${TSTAMP}" >
+        <touch datetime="${formattedTimestamp}" >
             <fileset dir="${tmp.dir}" includes="simple-file"/>
         </touch>
     </target>
 
     <target name="testMappedFileset">
-        <touch file="${tmp.dir}/touchtest" datetime="${DSTAMP}:${TSTAMP}" />
+        <touch file="${tmp.dir}/touchtest" datetime="${formattedTimestamp}" />
         <touch>
             <fileset file="${tmp.dir}/touchtest" />
             <mapper type="composite">
@@ -52,10 +54,18 @@
     </target>
 
     <target name="testMappedFilelist">
-        <touch datetime="${DSTAMP}:${TSTAMP}">
+        <touch datetime="${formattedTimestamp}">
             <filelist dir="." files="${tmp.dir}/idonotexist" />
             <mapper type="merge" to="${tmp.dir}/touchtest" />
         </touch>
+    </target>
+
+    <target name="testMillis">
+        <touch file="${tmp.dir}/millis-file" millis="946684799864" /> <!-- Friday, December 31, 1999 11:59:59.864 PM -->
+    </target>
+
+    <target name="testSeconds">
+        <touch file="${tmp.dir}/seconds-file" seconds="946684799" /> <!-- Friday, December 31, 1999 11:59:59 PM -->
     </target>
 
     <target name="main"/>

--- a/test/etc/types/selectors/DateSelectorTest.xml
+++ b/test/etc/types/selectors/DateSelectorTest.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="test.dateselector" basedir="." default="main">
+    <property name="tmp.dir" value="tmp/date"/>
+
+    <resolvepath propertyName="input.dir" dir="${tmp.dir}" path="testinput"/>
+    <resolvepath propertyName="output.dir" dir="${tmp.dir}" path="testoutput"/>
+
+    <target name="setup">
+        <mkdir dir="${input.dir}"/>
+        <mkdir dir="${output.dir}"/>
+    </target>
+
+    <target name="clean">
+        <delete dir="${input.dir}"/>
+        <delete dir="${output.dir}"/>
+    </target>
+
+    <target name="testSecondsWithDefaults">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testSecondsWithWhenAfter">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" when="after" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testSecondsWithWhenBefore">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" when="before" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testSecondsGranularitySixtySeconds">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" granularity="60" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testMillis">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date millis="${epoch.millis}" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testInvalidWhen">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="100000" when="ever" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testInvalidAttribute">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="100000" moonpie="Sheldon" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="main">
+        <echo msg="This test build file is not executable."/>
+    </target>
+</project>

--- a/test/etc/types/selectors/DifferentSelectorTest.xml
+++ b/test/etc/types/selectors/DifferentSelectorTest.xml
@@ -19,8 +19,8 @@
     </target>
 
     <target name="testSameTime">
-        <touch file="${a}/a.txt" millis="102134111"/>
-        <touch file="${b}/a.txt" millis="102134111"/>
+        <touch file="${a}/a.txt" seconds="102134111"/>
+        <touch file="${b}/a.txt" seconds="102134111"/>
         <copy todir="${result}">
             <fileset dir="${b}">
                 <different targetdir="${a}" ignoreContents="true" ignoreFileTimes="false"/>
@@ -29,8 +29,8 @@
     </target>
 
     <target name="testDifferentTime">
-        <touch file="${a}/b.txt" millis="102134111"/>
-        <touch file="${b}/b.txt" millis="102134200"/>
+        <touch file="${a}/b.txt" seconds="102134111"/>
+        <touch file="${b}/b.txt" seconds="102134200"/>
         <copy todir="${result}">
             <fileset dir="${b}">
                 <different targetdir="${a}" ignoreContents="true" ignoreFileTimes="false" />


### PR DESCRIPTION
Fixes: #1449

Changed code for TouchTask and DateSelector to be based on seconds instead of milliseconds.

Corrected tests to use appropriate test date format compatible with strtotime.
