### PR TITLE
Changed arg passed to phploc

### DIFF
--- a/test/etc/tasks/system/ExecTest.xml
+++ b/test/etc/tasks/system/ExecTest.xml
@@ -202,7 +202,7 @@
         <property environment="env"/>
         <exec executable="phploc" outputProperty="envtest" resolveexecutable="true" searchpath="true">
             <env key="Path" path="${env.Path};${project.basedir}\..\..\..\..\bin"/>
-            <arg value="-V"/>
+            <arg value="-v"/>
         </exec>
     </target>
 


### PR DESCRIPTION
Changed argument passed to phploc in testNestedEnv from -V to -v. phploc
7.x doesn't support -V anymore.