### PR TITLE
[DateSelector] Add tests and correct behavior

### DIFF
--- a/classes/phing/types/selectors/DateSelector.php
+++ b/classes/phing/types/selectors/DateSelector.php
@@ -115,7 +115,7 @@ class DateSelector extends BaseExtendSelector
                 "Date of " . $dateTime
                 . " Cannot be parsed correctly. It should be in"
                 . " a format parsable by PHP's strtotime() function."
-                );
+            );
         } else {
             $this->dateTime = $dateTime;
             $this->setSeconds($dt);
@@ -206,15 +206,14 @@ class DateSelector extends BaseExtendSelector
     {
         if ($this->dateTime === null && $this->seconds < 0) {
             $this->setError(
-                "You must provide a datetime or the number of "
-                . "seconds."
-                );
+                "You must provide a datetime or the number of seconds."
+            );
         } elseif ($this->seconds < 0) {
             $this->setError(
                 "Date of " . $this->dateTime
                 . " results in negative seconds"
                 . " value relative to epoch (January 1, 1970, 00:00:00 GMT)."
-                );
+            );
         }
     }
 

--- a/classes/phing/types/selectors/DateSelector.php
+++ b/classes/phing/types/selectors/DateSelector.php
@@ -34,6 +34,7 @@ class DateSelector extends BaseExtendSelector
     private $granularity = 0;
     private $cmp = 2;
     public const MILLIS_KEY = "millis";
+    public const SECONDS_KEY = "seconds";
     public const DATETIME_KEY = "datetime";
     public const CHECKDIRS_KEY = "checkdirs";
     public const GRANULARITY_KEY = "granularity";
@@ -97,7 +98,7 @@ class DateSelector extends BaseExtendSelector
      */
     public function setMillis($millis)
     {
-        $this->setSeconds((int) $millis * 1000);
+        $this->setSeconds((int) $millis / 1000);
     }
 
     /**
@@ -109,12 +110,12 @@ class DateSelector extends BaseExtendSelector
     public function setDatetime($dateTime)
     {
         $dt = strtotime($dateTime);
-        if ($dt == -1) {
+        if (false === $dt) {
             $this->setError(
                 "Date of " . $dateTime
                 . " Cannot be parsed correctly. It should be in"
                 . " a format parsable by PHP's strtotime() function."
-            );
+                );
         } else {
             $this->dateTime = $dateTime;
             $this->setSeconds($dt);
@@ -132,7 +133,7 @@ class DateSelector extends BaseExtendSelector
     }
 
     /**
-     * Sets the number of milliseconds leeway we will give before we consider
+     * Sets the number of seconds leeway we will give before we consider
      * a file not to have matched a date.
      *
      * @param int $granularity
@@ -151,7 +152,7 @@ class DateSelector extends BaseExtendSelector
     public function setWhen($cmp)
     {
         $idx = array_search($cmp, self::$timeComparisons, true);
-        if ($idx === null) {
+        if (false === $idx) {
             $this->setError("Invalid value for " . self::WHEN_KEY . ": " . $cmp);
         } else {
             $this->cmp = $idx;
@@ -174,6 +175,9 @@ class DateSelector extends BaseExtendSelector
                 switch (strtolower($paramname)) {
                     case self::MILLIS_KEY:
                         $this->setMillis($parameters[$i]->getValue());
+                        break;
+                    case self::SECONDS_KEY:
+                        $this->setSeconds($parameters[$i]->getValue());
                         break;
                     case self::DATETIME_KEY:
                         $this->setDatetime($parameters[$i]->getValue());
@@ -204,13 +208,13 @@ class DateSelector extends BaseExtendSelector
             $this->setError(
                 "You must provide a datetime or the number of "
                 . "seconds."
-            );
+                );
         } elseif ($this->seconds < 0) {
             $this->setError(
                 "Date of " . $this->dateTime
                 . " results in negative seconds"
                 . " value relative to epoch (January 1, 1970, 00:00:00 GMT)."
-            );
+                );
         }
     }
 

--- a/test/classes/phing/types/selectors/DateSelectorTest.php
+++ b/test/classes/phing/types/selectors/DateSelectorTest.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+
+/**
+ * Class SelectorUtilsTest
+ *
+ * Test cases for SelectorUtils
+ */
+class DateSelectorTest extends BuildFileTest
+{
+    const TWENTY_FOUR_HOURS_IN_SECONDS = (24 * 60 * 60);
+
+    private $inputDir;
+    private $outputDir;
+
+    private static $fileStateMsgs = array();
+
+
+    /**
+     * {@inheritDoc}
+     * @see \PHPUnit\Framework\TestCase::setUpBeforeClass()
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$fileStateMsgs['Before'] = array();
+        self::$fileStateMsgs['Now'] = array();
+        self::$fileStateMsgs['After'] = array();
+
+        self::$fileStateMsgs['Before'][true] = 'Before file should not exist in the output directory';
+        self::$fileStateMsgs['Before'][false] = 'Before file should exist in the output directory';
+
+        self::$fileStateMsgs['Now'][true] = 'Now file should not exist in the output directory';
+        self::$fileStateMsgs['Now'][false] = 'Now file should exist in the output directory';
+
+        self::$fileStateMsgs['After'][true] = 'After file should not exist in the output directory';
+        self::$fileStateMsgs['After'][false] = 'After file should exist in the output directory';
+    }
+
+    private static function getFileStateMsg(string $file, bool $isNot): string
+    {
+        return self::$fileStateMsgs[$file][$isNot];
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \PHPUnit\Framework\TestCase::tearDownAfterClass()
+     */
+    public static function tearDownAfterClass(): void
+    {
+        self::$fileStateMsgs = array();
+    }
+
+    public function setUp(): void
+    {
+        $this->configureProject(
+            PHING_TEST_BASE . '/etc/types/selectors/DateSelectorTest.xml'
+        );
+        $this->executeTarget('setup');
+
+        $project = $this->getProject();
+        $this->inputDir = $project->getProperty('input.dir');
+        $this->outputDir = rtrim($project->getProperty('output.dir'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+
+    public function tearDown(): void
+    {
+        $this->executeTarget('clean');
+    }
+
+    /**
+     * Creates a test file in the specified directory with the specified
+     * creation time.
+     *
+     * @param string $dir The directory where the test file should be created.
+     * @param int $timestamp The timestamp to touch the file with (in seconds
+     *              since the epoch).
+     *
+     * @return string The fully qualified name of the test file.
+     */
+    private function createTestFile(string $dir, int $timestamp): string
+    {
+        $file = tempnam($dir, 'dst');
+        $writeCnt = file_put_contents($file, 'DateSelectorTest file');
+        if (false !== $writeCnt) {
+            touch($file, $timestamp);
+        } else {
+            $this->fail('Unable to create test file: ' . $file);
+        }
+
+        return $file;
+    }
+
+    /*
+     * Test using seconds attribute
+     *
+     * when defaults to equal
+     * granularity defaults to 0
+     */
+    public function testSecondsWithDefaults()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile), self::getFileStateMsg('After', true));
+        $this->assertFileExists($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', false));
+    }
+
+    /*
+     * Test using seconds attribute with when set to after
+     *
+     * granularity defaults to 0
+     */
+    public function testSecondsWithWhenAfter()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', true));
+        $this->assertFileExists($this->outputDir . basename($afterFile), self::getFileStateMsg('After', false));
+    }
+
+    /*
+     * Test using seconds attribute with when set to before
+     *
+     * granularity defaults to 0
+     */
+    public function testSecondsWithWhenBefore()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile), self::getFileStateMsg('After', true));
+        $this->assertFileExists($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', false));
+    }
+
+    /*
+     * Test using seconds attribute with granularity at 60
+     *
+     * when defaults to equal
+     */
+    public function testSecondsGranularitySixtySeconds()
+    {
+        $epochSeconds = time();
+
+        $this->getProject()->setProperty('epoch.seconds', $epochSeconds);
+
+        $inWindowFiles = array(
+            '-60s' => $this->createTestFile($this->inputDir, $epochSeconds - 60),
+            '-59s' => $this->createTestFile($this->inputDir, $epochSeconds - 59),
+            '-30s' => $this->createTestFile($this->inputDir, $epochSeconds - 30),
+            '-+0s' => $this->createTestFile($this->inputDir, $epochSeconds),
+            '+30s' => $this->createTestFile($this->inputDir, $epochSeconds + 30),
+            '+59s' => $this->createTestFile($this->inputDir, $epochSeconds + 59),
+            '+60s' => $this->createTestFile($this->inputDir, $epochSeconds + 60)
+        );
+
+        $outOfWindowFiles = array(
+            '-24h' => $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS),
+            '-61s' => $this->createTestFile($this->inputDir, $epochSeconds - 61),
+            '+61s' => $this->createTestFile($this->inputDir, $epochSeconds + 61),
+            '+24h' => $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS)
+        );
+
+        $this->executeTarget(__FUNCTION__);
+
+        foreach ($inWindowFiles as $offset => $file) {
+            $this->assertFileExists($this->outputDir . basename($file), $offset . ' file missing from output directory');
+        }
+
+        foreach ($outOfWindowFiles as $file) {
+            $this->assertFileDoesNotExist($this->outputDir . basename($file), $offset . ' file unexpected in output directory');
+        }
+    }
+
+    /*
+     * Test using datetime attribute
+     *
+     * when defaults to equal
+     * granularity defaults to 0
+     */
+    public function testDateTimeWithDefaults()
+    {
+        $dateTime = '01/01/2001 12:00 AM';
+
+        $epochSeconds = strtotime($dateTime);
+
+        $this->getProject()->setProperty('datetime', $dateTime);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile), self::getFileStateMsg('After', true));
+        $this->assertFileExists($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', false));
+    }
+
+    /*
+     * Test using datetime attribute with when set to after
+     *
+     * granularity defaults to 0
+     */
+    public function testDateTimeWithWhenAfter()
+    {
+        $dateTime = '01/01/1999 12:00 AM';
+
+        $epochSeconds = strtotime($dateTime);
+
+        $this->getProject()->setProperty('datetime', '01/01/1999 12:00 AM');
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', true));
+        $this->assertFileExists($this->outputDir . basename($afterFile), self::getFileStateMsg('After', false));
+    }
+
+    /*
+     * Test using datetime attribute with when set to before
+     *
+     * granularity defaults to 0
+     */
+    public function testDateTimeWithWhenBefore()
+    {
+        $dateTime = '01/01/1975 12:00 PM';
+
+        $epochSeconds = strtotime($dateTime);
+
+        $this->getProject()->setProperty('datetime', $dateTime);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile), self::getFileStateMsg('After', true));
+        $this->assertFileExists($this->outputDir . basename($beforeFile), self::getFileStateMsg('Now', false));
+    }
+
+    /*
+     * Test using datetime attribute with granularity at 60
+     *
+     * when defaults to equal
+     */
+    public function testDateTimeGranularityThirtySeconds()
+    {
+        $dateTime = '01/01/1971 05:12 AM';
+
+        $epochSeconds = strtotime($dateTime);
+
+        $this->getProject()->setProperty('datetime', $dateTime);
+
+        $inWindowFiles = array(
+            '-30s' => $this->createTestFile($this->inputDir, $epochSeconds - 30),
+            '-29s' => $this->createTestFile($this->inputDir, $epochSeconds - 29),
+            '-15s' => $this->createTestFile($this->inputDir, $epochSeconds - 15),
+            '-+0s' => $this->createTestFile($this->inputDir, $epochSeconds),
+            '+15s' => $this->createTestFile($this->inputDir, $epochSeconds + 15),
+            '+29s' => $this->createTestFile($this->inputDir, $epochSeconds + 29),
+            '+30s' => $this->createTestFile($this->inputDir, $epochSeconds + 30)
+        );
+
+        $outOfWindowFiles = array(
+            '-24h' => $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS),
+            '-31s' => $this->createTestFile($this->inputDir, $epochSeconds - 31),
+            '+31s' => $this->createTestFile($this->inputDir, $epochSeconds + 31),
+            '+24h' => $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS)
+        );
+
+        $this->executeTarget(__FUNCTION__);
+
+        foreach ($inWindowFiles as $offset => $file) {
+            $this->assertFileExists($this->outputDir . basename($file), $offset . ' file missing from output directory');
+        }
+
+        foreach ($outOfWindowFiles as $offset => $file) {
+            $this->assertFileDoesNotExist($this->outputDir . basename($file), $offset . ' file unexpected in output directory');
+        }
+    }
+
+    /*
+     * Test using millis attribute
+     *
+     * when defaults to equal
+     * granularity defaults to 0
+     */
+    public function testMillisWithDefaults()
+    {
+        $epochSeconds = time();
+        $epochMillis = ($epochSeconds * 1000) + rand(0, 999);
+
+        $this->getProject()->setProperty('epoch.millis', $epochMillis);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - 60 * 1000);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + 60 * 1000);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile), self::getFileStateMsg('After', true));
+        $this->assertFileExists($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', false));
+    }
+
+
+    /*
+     * Test using millis attribute with when set to after
+     *
+     * granularity defaults to 0
+     */
+    public function testMillisWithWhenAfter()
+    {
+        $epochSeconds = time();
+        $epochMillis = ($epochSeconds * 1000) + rand(0, 999);
+
+        $this->getProject()->setProperty('epoch.millis', $epochMillis);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', true));
+        $this->assertFileExists($this->outputDir . basename($afterFile), self::getFileStateMsg('After', false));
+    }
+
+    /*
+     * Test using millis attribute with when set to before
+     *
+     * granularity defaults to 0
+     */
+    public function testMillisWithWhenBefore()
+    {
+        $epochSeconds = time();
+        $epochMillis = ($epochSeconds * 1000) + rand(0, 999);
+
+        $this->getProject()->setProperty('epoch.millis', $epochMillis);
+
+        $beforeFile = $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS);
+        $nowFile = $this->createTestFile($this->inputDir, $epochSeconds);
+        $afterFile = $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS);
+
+        $this->executeTarget(__FUNCTION__);
+
+        $this->assertFileDoesNotExist($this->outputDir . basename($nowFile), self::getFileStateMsg('Now', true));
+        $this->assertFileDoesNotExist($this->outputDir . basename($afterFile), self::getFileStateMsg('After', true));
+        $this->assertFileExists($this->outputDir . basename($beforeFile), self::getFileStateMsg('Before', false));
+    }
+
+    /*
+     * Test using millis attribute with granularity at 60
+     *
+     * when defaults to equal
+     */
+    public function testMillisGranularitySixSeconds()
+    {
+        $epochSeconds = time();
+        $epochMillis = ($epochSeconds * 1000) + rand(0, 999);
+
+        $this->getProject()->setProperty('epoch.millis', $epochMillis);
+
+        $inWindowFiles = array(
+            '-6s' => $this->createTestFile($this->inputDir, $epochSeconds - 6),
+            '-5s' => $this->createTestFile($this->inputDir, $epochSeconds - 5),
+            '-3s' => $this->createTestFile($this->inputDir, $epochSeconds - 3),
+            '+-0s' => $this->createTestFile($this->inputDir, $epochSeconds),
+            '+3s' => $this->createTestFile($this->inputDir, $epochSeconds + 3),
+            '+5s' => $this->createTestFile($this->inputDir, $epochSeconds + 5),
+            '+6s' => $this->createTestFile($this->inputDir, $epochSeconds + 6)
+        );
+
+        $outOfWindowFiles = array(
+            '-24h' => $this->createTestFile($this->inputDir, $epochSeconds - self::TWENTY_FOUR_HOURS_IN_SECONDS),
+            '-7s' => $this->createTestFile($this->inputDir, $epochSeconds - 7),
+            '+7s' => $this->createTestFile($this->inputDir, $epochSeconds + 7),
+            '+24h' => $this->createTestFile($this->inputDir, $epochSeconds + self::TWENTY_FOUR_HOURS_IN_SECONDS)
+        );
+
+        $this->executeTarget(__FUNCTION__);
+
+        foreach ($inWindowFiles as $offset => $file) {
+            $this->assertFileExists($this->outputDir . basename($file), $offset . ' file missing from the output directory');
+        }
+
+        foreach ($outOfWindowFiles as $offset => $file) {
+            $this->assertFileDoesNotExist($this->outputDir . basename($file), $offset . ' file unexpected in the output directory');
+        }
+    }
+
+    /*
+     * Test using seconds attribute
+     *
+     * when defaults to equal
+     * granularity defaults to 0
+     */
+    public function testSecondsInvalidSeconds()
+    {
+        $this->expectBuildException(__FUNCTION__, 'seconds has invalid value');
+    }
+
+    /*
+     * Test using datetime attribute with and invalid value
+     */
+    public function testDateTimeInvalidDateTime()
+    {
+        $this->expectBuildException(__FUNCTION__, 'datetime has invalid value');
+    }
+
+    /*
+     * Test using invalid datetime attribute
+     */
+    public function testDateTimeNotDateTime()
+    {
+        $this->expectBuildException(__FUNCTION__, 'datetime has invalid value');
+    }
+
+    /*
+     * Test using invalid millis attribute
+     */
+    public function testMillisInvalidMillis()
+    {
+        $this->expectBuildException(__FUNCTION__, 'millis has invalid value');
+    }
+
+    /*
+     * Test using an invalid when value
+     */
+    public function testInvalidWhen()
+    {
+        $this->expectBuildException(__FUNCTION__, 'when attribute has invalid value');
+    }
+
+    /*
+     * Test using an invalid when value
+     */
+    public function testInvalidAttribute()
+    {
+        $this->expectBuildException(__FUNCTION__, 'invalid attribute for task');
+    }
+}

--- a/test/etc/types/selectors/DateSelectorTest.xml
+++ b/test/etc/types/selectors/DateSelectorTest.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="test.dateselector" basedir="." default="main">
+    <property name="tmp.dir" value="tmp/date"/>
+
+    <resolvepath propertyName="input.dir" dir="${tmp.dir}" path="testinput"/>
+    <resolvepath propertyName="output.dir" dir="${tmp.dir}" path="testoutput"/>
+
+    <target name="setup">
+        <mkdir dir="${input.dir}"/>
+        <mkdir dir="${output.dir}"/>
+    </target>
+
+    <target name="clean">
+        <delete dir="${input.dir}"/>
+        <delete dir="${output.dir}"/>
+    </target>
+
+    <target name="testSecondsWithDefaults">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testSecondsWithWhenAfter">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" when="after" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testSecondsWithWhenBefore">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" when="before" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testSecondsGranularitySixtySeconds">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="${epoch.seconds}" granularity="60" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testSecondsInvalidSeconds">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="-7313" />
+            </fileset>
+        </copy>
+    </target>
+
+
+    <target name="testDateTimeWithDefaults">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date datetime="${datetime}" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testDateTimeWithWhenAfter">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date datetime="${datetime}" when="after" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testDateTimeWithWhenBefore">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date datetime="${datetime}" when="before" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testDateTimeGranularityThirtySeconds">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date datetime="${datetime}" granularity="30" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testDateTimeInvalidDateTime">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date datetime="01/01/1965 05:12 AM" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testDateTimeNotDateTime">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date datetime="Not A DateTime" />
+            </fileset>
+        </copy>
+    </target>
+
+
+    <target name="testMillisWithDefaults">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date millis="${epoch.millis}" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testMillisWithWhenAfter">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date millis="${epoch.millis}" when="after" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testMillisWithWhenBefore">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date millis="${epoch.millis}" when="before" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testMillisGranularitySixSeconds">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date millis="${epoch.millis}" granularity="6" />
+            </fileset>
+        </copy>
+    </target>
+
+
+    <target name="testDateTimeInvalidMillis">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date millis="-51441455" />
+            </fileset>
+        </copy>
+    </target>
+
+
+    <target name="testInvalidWhen">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="100000" when="ever" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="testInvalidAttribute">
+        <copy todir="${output.dir}">
+            <fileset dir="${input.dir}">
+                <date seconds="100000" moonpie="Sheldon" />
+            </fileset>
+        </copy>
+    </target>
+
+    <target name="main">
+        <echo msg="This test build file is not executable."/>
+    </target>
+</project>


### PR DESCRIPTION
Fixes #1458, #1459, #1461, #1462

- Correct check of return value from array_search() in setWhen() #1458
- Correct check of return value from strtotime() in setDatetime() #1459
- Change PHPDoc for setGranularity to reflect that it uses seconds #1461
- Divide by 1000, not multipy in setMillis to convert to seconds #1462