### PR TITLE
[php 8.0 compat] fix php warning:  Private methods cannot be final

### DIFF
--- a/classes/phing/listener/AnsiColorLogger.php
+++ b/classes/phing/listener/AnsiColorLogger.php
@@ -157,7 +157,7 @@ class AnsiColorLogger extends DefaultLogger
      * Set the colors to use from a property file specified by the
      * special ant property ant.logger.defaults
      */
-    final private function setColors()
+    private function setColors()
     {
 
         $userColorFile = Phing::getProperty("phing.logger.defaults");

--- a/classes/phing/listener/HtmlColorLogger.php
+++ b/classes/phing/listener/HtmlColorLogger.php
@@ -88,7 +88,7 @@ class HtmlColorLogger extends DefaultLogger
      * Set the colors to use from a property file specified in the
      * special phing property file "phing/listener/defaults.properties".
      */
-    final private function setColors()
+    private function setColors()
     {
 
         $systemColorFile = new PhingFile(Phing::getResourcePath("phing/listener/defaults.properties"));

--- a/classes/phing/tasks/system/CvsPassTask.php
+++ b/classes/phing/tasks/system/CvsPassTask.php
@@ -387,7 +387,7 @@ class CvsPassTask extends Task
      * @param $password
      * @return string
      */
-    final private function mangle($password)
+    private function mangle($password)
     {
         $buf = "";
         for ($i = 0, $plen = strlen($password); $i < $plen; $i++) {


### PR DESCRIPTION
Private methods cannot be final as they are never overridden by other classes