### PR TITLE
[SassTask] [core] - Fixed Filesystem::listContents for numeric filenames.

### DIFF
--- a/src/Phing/Io/FileSystem.php
+++ b/src/Phing/Io/FileSystem.php
@@ -869,17 +869,14 @@ abstract class FileSystem
      */
     public function listContents(File $f)
     {
-        $filenames = array_keys(
+        return array_map('strval', array_keys(
             iterator_to_array(
                 new FilesystemIterator(
                     $f->getAbsolutePath(),
                     FilesystemIterator::KEY_AS_FILENAME
                 )
             )
-        );
-
-        // make sure numeric filenames (e.g. 11) are properly treated as strings
-        return array_map('strval', $filenames);
+        ));
     }
 
     /**

--- a/src/Phing/Io/FileSystem.php
+++ b/src/Phing/Io/FileSystem.php
@@ -869,7 +869,7 @@ abstract class FileSystem
      */
     public function listContents(File $f)
     {
-        return array_keys(
+        $filenames = array_keys(
             iterator_to_array(
                 new FilesystemIterator(
                     $f->getAbsolutePath(),
@@ -877,6 +877,9 @@ abstract class FileSystem
                 )
             )
         );
+
+        // make sure numeric filenames (e.g. 11) are properly treated as strings
+        return array_map('strval', $filenames);
     }
 
     /**

--- a/src/Phing/Util/Timer.php
+++ b/src/Phing/Util/Timer.php
@@ -104,7 +104,8 @@ class Timer
     /**
      * @return bool
      */
-    public function isRunning() {
+    public function isRunning()
+    {
         return $this->running;
     }
 }

--- a/tests/Phing/Io/FileSystemTest.php
+++ b/tests/Phing/Io/FileSystemTest.php
@@ -102,4 +102,16 @@ class FileSystemTest extends \PHPUnit\Framework\TestCase
         $path = $fs->which('zx:\tasword.bin');
         $this->assertEquals($path, false);
     }
+
+    public function testListContentsWithNumericName()
+    {
+        $fs = FileSystem::getFileSystem();
+
+        $parentDir = new File(__DIR__ . '/../../etc/system/io/testdir');
+        $contents = $fs->listContents($parentDir);
+
+        foreach ($contents as $filename) {
+            self::assertIsString($filename);
+        }
+    }
 }

--- a/tests/classes/phing/tasks/ext/SassTask/Integration/SassCompilerTest.php
+++ b/tests/classes/phing/tasks/ext/SassTask/Integration/SassCompilerTest.php
@@ -72,13 +72,13 @@ class SassCompilerTest extends TestCase
 
     public function testItThrowsExceptionWhenFailOnErrorIsSet(): void
     {
+        $this->expectException(BuildException::class);
+
         $this->compiler->compile(
             self::SASS_TEST_BASE . 'non-existing.sass',
             self::SASS_TEST_BASE . 'test.css',
             true
         );
-
-        $this->expectException(BuildException::class);
 
         $this->assertFileDoesNotExist(self::SASS_TEST_BASE . 'test.css');
     }


### PR DESCRIPTION
Fixed an issue that affects all filesystem manipulation tasks dealing with files and directories with all-numeric names and often causes build failures and/or infinite directory traversal loops. Added a simple test for the fix.

Fixed the FailOnError test bug.