### PR TITLE
[core] Fixed deprecation warnings - PHP ^8.1

### DIFF
--- a/src/Phing/PropertyHelper.php
+++ b/src/Phing/PropertyHelper.php
@@ -427,9 +427,9 @@ class PropertyHelper
             return $o;
         }
 
-        $found = $this->properties[$name] ?? '';
+        $found = $this->properties[$name] ?? null;
         // check to see if there are unresolved property references
-        if (false !== strpos($found, '${')) {
+        if ($found !== null && false !== strpos($found, '${')) {
             // attempt to resolve properties
             $found = $this->replaceProperties($found, null);
             if (StringHelper::startsWith('${', $found) && StringHelper::endsWith('}', $found)) {

--- a/src/Phing/PropertyHelper.php
+++ b/src/Phing/PropertyHelper.php
@@ -427,7 +427,7 @@ class PropertyHelper
             return $o;
         }
 
-        $found = $this->properties[$name] ?? null;
+        $found = $this->properties[$name] ?? '';
         // check to see if there are unresolved property references
         if (false !== strpos($found, '${')) {
             // attempt to resolve properties

--- a/src/Phing/Util/PregEngine.php
+++ b/src/Phing/Util/PregEngine.php
@@ -47,7 +47,7 @@ class PregEngine implements RegexpEngine
      * @link http://php.net/manual/en/reference.pcre.pattern.modifiers.php
      * @var  string
      */
-    private $modifiers = null;
+    private $modifiers = '';
 
     /**
      * Set the limit.


### PR DESCRIPTION
* `strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated`
* `preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated`

Related to https://github.com/phingofficial/phing/pull/1534/checks?check_run_id=1894970221