### PR TITLE
Remove currentTimeMillis

### DIFF
--- a/src/Phing/Listener/DefaultLogger.php
+++ b/src/Phing/Listener/DefaultLogger.php
@@ -144,7 +144,7 @@ class DefaultLogger implements StreamRequiredBuildLogger
      */
     public function buildStarted(BuildEvent $event)
     {
-        $this->startTime = Phing::currentTimeMillis();
+        $this->startTime = microtime(true);
         if ($this->msgOutputLevel >= Project::MSG_INFO) {
             $this->printMessage(
                 "Buildfile: " . $event->getProject()->getProperty("phing.file"),
@@ -170,7 +170,7 @@ class DefaultLogger implements StreamRequiredBuildLogger
 
             self::throwableMessage($msg, $error, Project::MSG_VERBOSE <= $this->msgOutputLevel);
         }
-        $msg .= PHP_EOL . "Total time: " . static::formatTime(Phing::currentTimeMillis() - $this->startTime) . PHP_EOL;
+        $msg .= PHP_EOL . "Total time: " . static::formatTime(microtime(true) - $this->startTime) . PHP_EOL;
 
         $error === null
             ? $this->printMessage($msg, $this->out, Project::MSG_VERBOSE)

--- a/src/Phing/Listener/JsonLogger.php
+++ b/src/Phing/Listener/JsonLogger.php
@@ -47,7 +47,7 @@ class JsonLogger extends XmlLogger
      */
     public function buildFinished(BuildEvent $event)
     {
-        $elapsedTime = Phing::currentTimeMillis() - $this->getBuildTimerStart();
+        $elapsedTime = microtime(true) - $this->getBuildTimerStart();
 
         $this->getBuildElement()->setAttribute(XmlLogger::TIME_ATTR, DefaultLogger::formatTime($elapsedTime));
 

--- a/src/Phing/Listener/ProfileLogger.php
+++ b/src/Phing/Listener/ProfileLogger.php
@@ -44,7 +44,7 @@ class ProfileLogger extends DefaultLogger
         if (@date_default_timezone_get() === 'UTC') {
             date_default_timezone_set('Europe/Berlin');
         }
-        $now = Phing::currentTimeMillis();
+        $now = microtime(true);
         $name = "Target " . $event->getTarget()->getName();
         $this->logStart($event, $now, $name);
         $this->profileData[] = $now;
@@ -75,7 +75,7 @@ class ProfileLogger extends DefaultLogger
     public function taskStarted(BuildEvent $event)
     {
         $name = $event->getTask()->getTaskName();
-        $now = Phing::currentTimeMillis();
+        $now = microtime(true);
         $this->logStart($event, $now, $name);
         $this->profileData[] = $now;
     }
@@ -99,7 +99,7 @@ class ProfileLogger extends DefaultLogger
     {
         $msg = null;
         if ($start != null) {
-            $diff = self::formatTime(Phing::currentTimeMillis() - $start);
+            $diff = self::formatTime(microtime(true) - $start);
             $msg = Phing::getProperty("line.separator") . $name . ": finished "
                 . date(self::$dateFormat, time()) . " ("
                 . $diff

--- a/src/Phing/Listener/ProgressLogger.php
+++ b/src/Phing/Listener/ProgressLogger.php
@@ -59,7 +59,7 @@ class ProgressLogger extends AnsiColorLogger
      */
     public function buildStarted(BuildEvent $event)
     {
-        $this->startTime = Phing::currentTimeMillis();
+        $this->startTime = microtime(true);
         $this->bar->setMessage($event->getProject()->getProperty("phing.file"), 'buildfile');
     }
 

--- a/src/Phing/Listener/TargetLogger.php
+++ b/src/Phing/Listener/TargetLogger.php
@@ -38,13 +38,13 @@ class TargetLogger extends AnsiColorLogger
         parent::targetStarted($event);
         $target = $event->getTarget();
         $this->targetName = $target->getName();
-        $this->targetStartTime = Phing::currentTimeMillis();
+        $this->targetStartTime = microtime(true);
     }
 
     public function targetFinished(BuildEvent $event)
     {
         $msg = PHP_EOL . "Target time: " . self::formatTime(
-            Phing::currentTimeMillis() - $this->targetStartTime
+            microtime(true) - $this->targetStartTime
         ) . PHP_EOL;
         $event->setMessage($msg, Project::MSG_INFO);
         $this->messageLogged($event);

--- a/src/Phing/Listener/XmlLogger.php
+++ b/src/Phing/Listener/XmlLogger.php
@@ -152,7 +152,7 @@ class XmlLogger implements BuildLogger
      */
     public function buildStarted(BuildEvent $event)
     {
-        $this->buildTimerStart = Phing::currentTimeMillis();
+        $this->buildTimerStart = microtime(true);
         $this->buildElement = $this->doc->createElement(XmlLogger::BUILD_TAG);
         $this->elementStack[] = $this->buildElement;
         $this->timesStack[] = $this->buildTimerStart;
@@ -178,7 +178,7 @@ class XmlLogger implements BuildLogger
             $this->doc->appendChild($xslt);
         }
 
-        $elapsedTime = Phing::currentTimeMillis() - $this->buildTimerStart;
+        $elapsedTime = microtime(true) - $this->buildTimerStart;
 
         $this->buildElement->setAttribute(XmlLogger::TIME_ATTR, DefaultLogger::formatTime($elapsedTime));
 
@@ -237,7 +237,7 @@ class XmlLogger implements BuildLogger
         $targetElement = $this->doc->createElement(XmlLogger::TARGET_TAG);
         $targetElement->setAttribute(XmlLogger::NAME_ATTR, $target->getName());
 
-        $this->timesStack[] = Phing::currentTimeMillis();
+        $this->timesStack[] = microtime(true);
         $this->elementStack[] = $targetElement;
     }
 
@@ -253,7 +253,7 @@ class XmlLogger implements BuildLogger
         $targetTimerStart = array_pop($this->timesStack);
         $targetElement = array_pop($this->elementStack);
 
-        $elapsedTime = Phing::currentTimeMillis() - $targetTimerStart;
+        $elapsedTime = microtime(true) - $targetTimerStart;
         $targetElement->setAttribute(XmlLogger::TIME_ATTR, DefaultLogger::formatTime($elapsedTime));
 
         $parentElement = $this->elementStack[count($this->elementStack) - 1];
@@ -274,7 +274,7 @@ class XmlLogger implements BuildLogger
         $taskElement->setAttribute(XmlLogger::NAME_ATTR, $task->getTaskName());
         $taskElement->setAttribute(XmlLogger::LOCATION_ATTR, (string) $task->getLocation());
 
-        $this->timesStack[] = Phing::currentTimeMillis();
+        $this->timesStack[] = microtime(true);
         $this->elementStack[] = $taskElement;
     }
 
@@ -290,7 +290,7 @@ class XmlLogger implements BuildLogger
         $taskTimerStart = array_pop($this->timesStack);
         $taskElement = array_pop($this->elementStack);
 
-        $elapsedTime = Phing::currentTimeMillis() - $taskTimerStart;
+        $elapsedTime = microtime(true) - $taskTimerStart;
         $taskElement->setAttribute(XmlLogger::TIME_ATTR, DefaultLogger::formatTime($elapsedTime));
 
         $parentElement = $this->elementStack[count($this->elementStack) - 1];

--- a/src/Phing/Phing.php
+++ b/src/Phing/Phing.php
@@ -1625,16 +1625,6 @@ class Phing
     }
 
     /**
-     * @return float
-     */
-    public static function currentTimeMillis()
-    {
-        [$usec, $sec] = explode(" ", microtime());
-
-        return ((float) $usec + (float) $sec);
-    }
-
-    /**
      * Sets the include path to PHP_CLASSPATH constant (if this has been defined).
      *
      * @throws ConfigurationException - if the include_path could not be set (for some bizarre reason)

--- a/src/Phing/Task/System/RecorderEntry.php
+++ b/src/Phing/Task/System/RecorderEntry.php
@@ -87,7 +87,7 @@ class RecorderEntry implements BuildLogger, SubBuildListener
      */
     public function __construct($name)
     {
-        $this->targetStartTime = Phing::currentTimeMillis();
+        $this->targetStartTime = microtime(true);
         $this->filename = $name;
         $this->loglevel = Project::MSG_INFO;
     }
@@ -177,7 +177,7 @@ class RecorderEntry implements BuildLogger, SubBuildListener
             Phing::getProperty('line.separator') . $event->getTarget()->getName() . ":",
             Project::MSG_INFO
         );
-        $this->targetStartTime = Phing::currentTimeMillis();
+        $this->targetStartTime = microtime(true);
     }
 
     /**
@@ -187,7 +187,7 @@ class RecorderEntry implements BuildLogger, SubBuildListener
     {
         $this->log("<< TARGET FINISHED -- " . $event->getTarget()->getName(), Project::MSG_DEBUG);
 
-        $time = DefaultLogger::formatTime(Phing::currentTimeMillis() - $this->targetStartTime);
+        $time = DefaultLogger::formatTime(microtime(true) - $this->targetStartTime);
 
         $this->log($event->getTarget()->getName() . ":  duration " . $time, Project::MSG_VERBOSE);
         flush();

--- a/src/Phing/Task/System/TouchTask.php
+++ b/src/Phing/Task/System/TouchTask.php
@@ -222,7 +222,7 @@ class TouchTask extends Task
         if ($this->seconds < 0) {
             $resetSeconds = true;
             // Note: this function actually returns seconds, not milliseconds (e.g. 1606505920.2657)
-            $this->seconds = Phing::currentTimeMillis();
+            $this->seconds = microtime(true);
         }
 
         if ($this->file !== null) {

--- a/tests/Phing/PhingTest.php
+++ b/tests/Phing/PhingTest.php
@@ -62,11 +62,6 @@ class PhingTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Timer::class, Phing::getTimer());
     }
 
-    public function testFloatOnCurrentTimeMillis()
-    {
-        $this->assertIsFloat(Phing::currentTimeMillis());
-    }
-
     public function testGetPhingVersion()
     {
         $this->assertStringStartsWith('Phing ', Phing::getPhingVersion());


### PR DESCRIPTION
I remove `\Phing\Phing::currentTimeMillis` function since it can be easily replaced by 'microtime(true)'