### PR TITLE
Add comment in test to prevent php8.1 compat issue

### DIFF
--- a/tests/etc/tasks/ext/pdepend/test.php
+++ b/tests/etc/tasks/ext/pdepend/test.php
@@ -2,7 +2,10 @@
 
 class Test
 {
-    public function test($a = 0)
+    /**
+     * @param int $a
+     */
+    public function testing($a = 0)
     {
         echo "Hello World";
     }


### PR DESCRIPTION
Without a comment pdepend will raise an error.
```
preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated
```