### PR TITLE
Add support for setting standard, outfile and format to phpcs task

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -5314,6 +5314,15 @@
                         </choice>
                     </attribute>
                 </optional>
+                <optional>
+                    <attribute name="standard"/>
+                </optional>
+                <optional>
+                    <attribute name="format"/>
+                </optional>
+                <optional>
+                    <attribute name="outfile"/>
+                </optional>
             </interleave>
             <zeroOrMore>
                 <ref name="fileset"/>

--- a/src/Phing/Task/Optional/PhpCSTask.php
+++ b/src/Phing/Task/Optional/PhpCSTask.php
@@ -21,6 +21,7 @@
 namespace Phing\Task\Optional;
 
 use Phing\Exception\BuildException;
+use Phing\Project;
 use Phing\Io\File;
 use Phing\Task;
 use Phing\Task\System\Element\LogLevelAware;
@@ -65,6 +66,15 @@ class PhpCSTask extends Task
     private $checkreturn = false;
 
     /** @var string */
+    private $standard = '';
+
+    /** @var string */
+    private $outfile = '';
+
+    /** @var string */
+    private $format = '';
+
+    /** @var string */
     private $bin = 'phpcs';
 
     public function __construct()
@@ -99,9 +109,27 @@ class PhpCSTask extends Task
         $this->bin = $bin;
     }
 
+    public function setFormat(string $format): void
+    {
+        $this->format = $format;
+        $this->project->log("Format set to $format", Project::MSG_VERBOSE);
+    }
+
+    public function setStandard(string $standard): void
+    {
+        $this->standard = $standard;
+        $this->project->log("Standard set to $standard", Project::MSG_VERBOSE);
+    }
+
     public function setFile(File $file): void
     {
         $this->file = $file;
+    }
+
+    public function setOutfile(string $outfile): void
+    {
+        $this->outfile = $outfile;
+        $this->project->log("Outfile set to $outfile", Project::MSG_VERBOSE);
     }
 
     public function main()
@@ -127,6 +155,15 @@ class PhpCSTask extends Task
 
         if ($this->ignoreAnnotations) {
             $toExecute->createArgument()->setValue('--ignore-annotations');
+        }
+        if ($this->format !== '') {
+            $toExecute->createArgument()->setValue(' --report=' . $this->format);
+        }
+        if ($this->standard !== '') {
+            $toExecute->createArgument()->setValue(' --standard=' . $this->standard);
+        }
+        if ($this->outfile !== '') {
+            $toExecute->createArgument()->setValue(' --report-file=' . $this->outfile);
         }
 
         if (null !== $this->file) {

--- a/tests/Phing/Task/Optional/PhpCSTaskTest.php
+++ b/tests/Phing/Task/Optional/PhpCSTaskTest.php
@@ -55,4 +55,16 @@ class PhpCSTaskTest extends BuildFileTest
         $this->expectNotToPerformAssertions();
         $this->executeTarget(__FUNCTION__);
     }
+
+    public function testFileSetInPhpCs1OutfileSet(): void
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertInLogs('Outfile set to /dev/null');
+    }
+
+    public function testFileSetInPhpCs1FormatSet(): void
+    {
+        $this->executeTarget(__FUNCTION__);
+        $this->assertInLogs('Format set to checkstyle');
+    }
 }

--- a/tests/etc/tasks/ext/phpcs/build.xml
+++ b/tests/etc/tasks/ext/phpcs/build.xml
@@ -12,4 +12,19 @@
         <fileset dir="../.." includes="**/*.php"/>
         </phpcs>
     </target>
+    <target name="testFileSetInPhpCs1FormatSet">
+        <phpcs bin="../../../../../bin/phpcs" format="checkstyle" level="debug" checkreturn="false" ignoreAnnotations="true" >
+        <fileset dir="../.." includes="**/*.php"/>
+        </phpcs>
+    </target>
+    <target name="testFileSetInPhpCs1StandardSet">
+        <phpcs bin="../../../../../bin/phpcs" standard="PSR12" level="debug" checkreturn="false" ignoreAnnotations="true" >
+        <fileset dir="../.." includes="**/*.php"/>
+        </phpcs>
+    </target>
+    <target name="testFileSetInPhpCs1OutfileSet">
+        <phpcs bin="../../../../../bin/phpcs" outfile="/dev/null" level="debug" checkreturn="false" ignoreAnnotations="true" >
+        <fileset dir="../.." includes="**/*.php"/>
+        </phpcs>
+    </target>
 </project>


### PR DESCRIPTION
This brings the phpcs task in line with most of the attributes used/specified in the phpcodesniffer task, making it easier to switch to the newer task.