### PR TITLE
Remove the default value before the required parameter.

### DIFF
--- a/classes/phing/tasks/ext/phpdoc/PhingPhpDocumentorSetup.php
+++ b/classes/phing/tasks/ext/phpdoc/PhingPhpDocumentorSetup.php
@@ -43,7 +43,7 @@ class PhingPhpDocumentorSetup extends phpDocumentor_setup
      * @param object $task The task we're working with, so we can pass it on to the ErrorTracker
      * @internal param string $configDir Directory in which to look for configuration files.
      */
-    public function __construct($configdir = null, $task)
+    public function __construct($configdir, $task)
     {
         global $_phpDocumentor_cvsphpfile_exts, $_phpDocumentor_setting, $_phpDocumentor_phpfile_exts;
 

--- a/classes/phing/util/FileUtils.php
+++ b/classes/phing/util/FileUtils.php
@@ -98,9 +98,9 @@ class FileUtils
     public function copyFile(
         PhingFile $sourceFile,
         PhingFile $destFile,
-        $overwrite = false,
-        $preserveLastModified = true,
-        &$filterChains = null,
+        $overwrite,
+        $preserveLastModified,
+        &$filterChains,
         Project $project,
         $mode = 0755,
         $preservePermissions = true


### PR DESCRIPTION
Fixed the case where a parameter with a default value followed by a required parameter was deprecated in PHP 8.0.0 and later.

Reference: https://www.php.net/manual/en/migration80.deprecated.php