### PR TITLE
Call vsprintf correctly in ChmodTask

### DIFF
--- a/classes/phing/tasks/system/ChmodTask.php
+++ b/classes/phing/tasks/system/ChmodTask.php
@@ -188,8 +188,8 @@ class ChmodTask extends Task
         }
 
         if (!$this->verbose) {
-            $this->log('Total files changed to ' . vsprintf('%o', $mode) . ': ' . $total_files);
-            $this->log('Total directories changed to ' . vsprintf('%o', $mode) . ': ' . $total_dirs);
+            $this->log('Total files changed to ' . vsprintf('%o', [$mode]) . ': ' . $total_files);
+            $this->log('Total directories changed to ' . vsprintf('%o', [$mode]) . ': ' . $total_dirs);
         }
 
     }
@@ -210,7 +210,7 @@ class ChmodTask extends Task
         try {
             $file->setMode($mode);
             if ($this->verbose) {
-                $this->log("Changed file mode on '" . $file->__toString() . "' to " . vsprintf("%o", $mode));
+                $this->log("Changed file mode on '" . $file->__toString() . "' to " . vsprintf("%o", [$mode]));
             }
         } catch (Exception $e) {
             if ($this->failonerror) {


### PR DESCRIPTION
`vsprint` expects its second argument to be an array. Old PHP versions silently also accepted a single non-array parameter that was "upgraded" to [$param].
This becomes an issue on PHP8, because it type-checks the parameter and issues an error accordingly.

This issue is already fixed in `main` and only exists in `oldstable`.