### PR TITLE
Fix potential bug with StringHelper::substring() when $value is boolean

### DIFF
--- a/classes/phing/tasks/system/PropertyTask.php
+++ b/classes/phing/tasks/system/PropertyTask.php
@@ -463,6 +463,10 @@ class PropertyTask extends Task
             // multiple passes.
 
             $value = $props->getProperty($name);
+            if (is_bool($value)) {
+                continue; // It's a boolean value, no need to resolve
+            }
+            
             $resolved = false;
             $resolveStack = array();
 


### PR DESCRIPTION
Fix a potential bug with PHP8 when `PropertyTask` try to resolve a boolean value.

---

In a project with Propel 1.6 and Phing 2.17 that I would like to upgrade to PHP8.  
I have some PHP Error when `PropertyTask` load the default `default.properties` file.  
```
[PHP Error] Trying to access array offset on value of type bool [line 268 of /usr/local/lib/php/phing/util/StringHelper.php]
```

I found the trouble was when `PropertyTask` try to resolve properties.  
When `true` is set, the property value is a boolean.  
And during the resolution process, `StringHelper::substring()` is called with `$value = true`.
So, a `[PHP Error]` is triggered at `StringHelper:268` because `strlen(true)` return `1`.

```ini
# default.properties sample
propel.packageObjectModel = true
propel.useDateTimeClass = true
```

