### PR TITLE
Update PHP requirement in Phar manifest

### DIFF
--- a/build/manifest.xml
+++ b/build/manifest.xml
@@ -6,6 +6,6 @@
         <license type="LGPL-3.0" url="https://github.com/phingofficial/phing/blob/main/LICENSE"/>
     </copyright>
     <requires>
-        <php version="^7.3"/>
+        <php version="^7.3 || ^8.0"/>
     </requires>
 </phar>


### PR DESCRIPTION
composer.json states `^7.3 || ^7.4 || ^8.0` as PHP version requirement,
so the Phar is supposed to be compatible with PHP 8.0 as well.  Since
`^7.3` implies compatibility with PHP 7.4, we don't add it explicitly
here.