### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/src/Phing/Type/FileList.php
+++ b/src/Phing/Type/FileList.php
@@ -29,6 +29,7 @@ use Phing\Io\File;
 use Phing\Io\FileReader;
 use Phing\Io\IOException;
 use Phing\Project;
+use ReturnTypeWillChange;
 
 /**
  * FileList represents an explicitly named list of files. FileLists
@@ -85,6 +86,7 @@ class FileList extends DataType implements IteratorAggregate
         }
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->getFiles($this->getProject()));


### PR DESCRIPTION
Fixed deprecated message:
```
Return type of Phing\Type\FileList::getIterator() should either be compatible with IteratorAggregate::getIterator():Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/phing/phing/src/Phing/Type/FileList.php:88
```