### PR TITLE
Relative symlinking (#695)

### DIFF
--- a/classes/phing/tasks/ext/SymlinkTask.php
+++ b/classes/phing/tasks/ext/SymlinkTask.php
@@ -207,6 +207,46 @@ class SymlinkTask extends Task
     }
 
     /**
+     * Given an existing path, convert it to a path relative to a given starting path.
+     *
+     * @param string $endPath   Absolute path of target
+     * @param string $startPath Absolute path where traversal begins
+     *
+     * @return string Path of target relative to starting path
+     */
+    public function makePathRelative($endPath, $startPath)
+    {
+        // Normalize separators on Windows
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $endPath = str_replace('\\', '/', $endPath);
+            $startPath = str_replace('\\', '/', $startPath);
+        }
+
+        // Split the paths into arrays
+        $startPathArr = explode('/', trim($startPath, '/'));
+        $endPathArr = explode('/', trim($endPath, '/'));
+
+        // Find for which directory the common path stops
+        $index = 0;
+        while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
+            ++$index;
+        }
+
+        // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
+        $depth = count($startPathArr) - $index;
+
+        // Repeated "../" for each level need to reach the common path
+        $traverser = str_repeat('../', $depth);
+
+        $endPathRemainder = implode('/', array_slice($endPathArr, $index));
+
+        // Construct $endPath from traversing to the common path, then to the remaining $endPath
+        $relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
+
+        return '' === $relativePath ? './' : $relativePath;
+    }
+
+    /**
      * Generates an array of directories / files to be linked
      * If _filesets is empty, returns getTarget()
      *
@@ -235,11 +275,7 @@ class SymlinkTask extends Task
                 throw new BuildException('Link must be an existing directory when using fileset');
             }
 
-            if ($this->isRelative()) {
-                $fromDir = $fs->getDir($this->getProject())->getPath();
-            } else {
-                $fromDir = $fs->getDir($this->getProject())->getAbsolutePath();
-            }
+            $fromDir = $fs->getDir($this->getProject())->getAbsolutePath();
 
             if (!is_dir($fromDir)) {
                 $this->log('Directory doesn\'t exist: ' . $fromDir, Project::MSG_WARN);
@@ -299,6 +335,11 @@ class SymlinkTask extends Task
     protected function symlink($target, $link)
     {
         $fs = FileSystem::getFileSystem();
+
+        if ($this->isRelative()) {
+           $link =(new PhingFile($link))->getAbsolutePath();
+           $target = rtrim($this->makePathRelative($target, dirname($link)), '/');
+        }
 
         if (is_link($link) && @readlink($link) == $target) {
             $this->log('Link exists: ' . $link, Project::MSG_INFO);


### PR DESCRIPTION
https://github.com/phingofficial/phing/pull/695 applies cleanly to Phing 2.17.0 and adds support for using relative symlinks in the manner described in that PR. We are unable to update to Phing 3 at the moment, so having this patch was helpful. I'm not sure if I've chosen the correct base branch for updating 2.x or if it is still being supported.