### PR TITLE
fix error: implicit conversion from float to int loses precision

### DIFF
--- a/classes/phing/listener/DefaultLogger.php
+++ b/classes/phing/listener/DefaultLogger.php
@@ -304,7 +304,7 @@ class DefaultLogger implements StreamRequiredBuildLogger
      */
     public static function formatTime($micros)
     {
-        $seconds = $micros;
+        $seconds = (int)$micros;
         $minutes = (int)floor($seconds / 60);
         if ($minutes >= 1) {
             return sprintf(


### PR DESCRIPTION
Hello!
Try run on php 8.1 cause errors
@siad007 @mrook 