### PR TITLE
get unit tests to pass on 32-bit systems

### DIFF
--- a/src/Phing/Type/Selector/DateSelector.php
+++ b/src/Phing/Type/Selector/DateSelector.php
@@ -99,7 +99,7 @@ class DateSelector extends BaseExtendSelector
      */
     public function setMillis($millis)
     {
-        $this->setSeconds((int) $millis / 1000);
+        $this->setSeconds((float) $millis / 1000);
     }
 
     /**

--- a/src/Phing/Util/SizeHelper.php
+++ b/src/Phing/Util/SizeHelper.php
@@ -58,7 +58,7 @@ class SizeHelper
     /**
      * Convert from bytes to any other valid unit.
      */
-    public static function fromBytesTo(int $bytes, string $unit): float
+    public static function fromBytesTo(float $bytes, string $unit): float
     {
         $multiple = self::findUnitMultiple($unit);
 
@@ -95,7 +95,7 @@ class SizeHelper
     /**
      * Finds the value in bytes of a single "unit".
      */
-    protected static function findUnitMultiple(string $unit): int
+    protected static function findUnitMultiple(string $unit): float
     {
         foreach (self::IEC as $exponent => $choices) {
             if (in_array(strtolower($unit), array_map('strtolower', $choices))) {

--- a/tests/Phing/Type/Selector/DateSelectorTest.php
+++ b/tests/Phing/Type/Selector/DateSelectorTest.php
@@ -187,7 +187,7 @@ class DateSelectorTest extends BuildFileTest
             $this->assertFileExists($this->outputDir . basename($file), $offset . ' file missing from output directory');
         }
 
-        foreach ($outOfWindowFiles as $file) {
+        foreach ($outOfWindowFiles as $offset => $file) {
             $this->assertFileDoesNotExist($this->outputDir . basename($file), $offset . ' file unexpected in output directory');
         }
     }

--- a/tests/Phing/Util/SizeHelperTest.php
+++ b/tests/Phing/Util/SizeHelperTest.php
@@ -115,7 +115,7 @@ class SizeHelperTest extends TestCase
     /**
      * @dataProvider fromBytesToProvider
      */
-    public function testFromBytesTo(int $bytes, string $unit, float $expected): void
+    public function testFromBytesTo(float $bytes, string $unit, float $expected): void
     {
         $converted = SizeHelper::fromBytesTo($bytes, $unit);
         $this->assertSame($expected, $converted);


### PR DESCRIPTION
Change a few spots from `int` to `float` to allow for `long` numbers to work on 32-bit systems.

Resolves: #1666

Signed-off-by: Charlie Cadwell <twoseascharlie@gmail.com>