### PR TITLE
DeleteTask: fix invalid passing argument by reference

### DIFF
--- a/classes/phing/tasks/system/DeleteTask.php
+++ b/classes/phing/tasks/system/DeleteTask.php
@@ -202,7 +202,8 @@ class DeleteTask extends Task
         foreach ($this->filelists as $fl) {
             try {
                 $files = $fl->getFiles($this->project);
-                $this->removeFiles($fl->getDir($this->project), $files, $empty = array());
+                $empty = array();
+                $this->removeFiles($fl->getDir($this->project), $files, $empty);
             } catch (BuildException $be) {
                 // directory doesn't exist or is not readable
                 if ($this->failonerror) {


### PR DESCRIPTION
Version: 2.17.x

This PR prevents the following error 
```
Fatal error: Uncaught Error: DeleteTask::removeFiles(): Argument #3 ($dirs) cannot be passed by reference in .../vendor/phing/phing/classes/phing/tasks/system/DeleteTask.php:205
```

Would it be possible to also release a new 2.17.x version? It would be terrific :) 