### PR TITLE
Declare $searchForThis property

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -162,6 +162,11 @@ class Phing
     private $emacsMode = false;
 
     /**
+     * @var string
+     */
+    private $searchForThis;
+
+    /**
      * Entry point allowing for more options from other front ends.
      *
      * This method encapsulates the complete build lifecycle.

--- a/classes/phing/parser/ElementHandler.php
+++ b/classes/phing/parser/ElementHandler.php
@@ -70,6 +70,12 @@ class ElementHandler extends AbstractHandler
     private $target;
 
     /**
+     * The phing project configurator object
+     * @var ProjectConfigurator
+     */
+    private $configurator;
+
+    /**
      *  Constructs a new NestedElement handler and sets up everything.
      *
      * @param  object  the ExpatParser object

--- a/classes/phing/parser/TargetHandler.php
+++ b/classes/phing/parser/TargetHandler.php
@@ -49,6 +49,12 @@ class TargetHandler extends AbstractHandler
     private $configurator;
 
     /**
+     * @var PhingXMLContext
+     */
+    private $context;
+
+
+    /**
      * Constructs a new TargetHandler
      *
      * @param AbstractSAXParser $parser

--- a/classes/phing/tasks/system/condition/ConditionBase.php
+++ b/classes/phing/tasks/system/condition/ConditionBase.php
@@ -36,7 +36,6 @@ include_once 'phing/parser/CustomChildCreator.php';
  * @version   $Id$
  * @package   phing.tasks.system.condition
  */
-#[\ReturnTypeWillChange]
 abstract class ConditionBase extends ProjectComponent
     implements IteratorAggregate, CustomChildCreator
 {

--- a/classes/phing/tasks/system/condition/ConditionBase.php
+++ b/classes/phing/tasks/system/condition/ConditionBase.php
@@ -36,6 +36,7 @@ include_once 'phing/parser/CustomChildCreator.php';
  * @version   $Id$
  * @package   phing.tasks.system.condition
  */
+#[\ReturnTypeWillChange]
 abstract class ConditionBase extends ProjectComponent
     implements IteratorAggregate, CustomChildCreator
 {
@@ -82,6 +83,7 @@ abstract class ConditionBase extends ProjectComponent
     /**
      * Required for IteratorAggregate
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ConditionEnumeration($this);
@@ -361,11 +363,13 @@ class ConditionEnumeration implements Iterator
     /**
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->outer->countConditions() > $this->num;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $o = $this->outer->conditions[$this->num];
@@ -376,6 +380,7 @@ class ConditionEnumeration implements Iterator
         return $o;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->num++;
@@ -384,11 +389,13 @@ class ConditionEnumeration implements Iterator
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->num;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->num = 0;

--- a/classes/phing/types/IterableFileSet.php
+++ b/classes/phing/types/IterableFileSet.php
@@ -27,6 +27,7 @@
  * @since 2.4.0
  * @internal
  */
+#[\ReturnTypeWillChange]
 class IterableFileSet
     extends FileSet
     implements IteratorAggregate
@@ -34,6 +35,7 @@ class IterableFileSet
     /**
      * @return Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->getFiles());

--- a/classes/phing/types/IterableFileSet.php
+++ b/classes/phing/types/IterableFileSet.php
@@ -27,7 +27,6 @@
  * @since 2.4.0
  * @internal
  */
-#[\ReturnTypeWillChange]
 class IterableFileSet
     extends FileSet
     implements IteratorAggregate


### PR DESCRIPTION
Due to the deprecation of dynamic properties in PHP 8.2 (https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties) any use of phing v2 results in:

```
$ vendor/bin/phing -v
Creation of dynamic property Phing::$searchForThis is deprecated
```

`$searchForThis` doesn't appear to need to be a class property as I can only see use in `Phing::execute()` but I've just followed suit with what's on the main branch for version 3.