### PR TITLE
PHP 8.2 deprecated fix

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -160,6 +160,8 @@ class Phing
 
     /** Whether or not output to the log is to be unadorned. */
     private $emacsMode = false;
+    
+    private $searchForThis = null;
 
     /**
      * Entry point allowing for more options from other front ends.


### PR DESCRIPTION
PHP 8.2: Creation of dynamic property Phing::$searchForThis is deprecated in vendor/phing/phing/classes/phing/Phing.php on line 362