### PR TITLE
Remove phpcpd and phploc refernce from composer.json

### DIFF
--- a/src/Phing/Task/Ext/Analyzer/composer.json
+++ b/src/Phing/Task/Ext/Analyzer/composer.json
@@ -30,8 +30,6 @@
   "extra": {
     "phing-custom-taskdefs": {
       "phpstan": "Phing\\Task\\Ext\\Analyzer\\Phpstan\\PHPStanTask",
-      "phpcpd": "Phing\\Task\\Ext\\Analyzer\\Phpcpd\\PHPCPDTask",
-      "phploc": "Phing\\Task\\Ext\\Analyzer\\Phploc\\PHPLocTask",
       "phpmd": "Phing\\Task\\Ext\\Analyzer\\Phpmd\\PHPMDTask",
       "phpdepend": "Phing\\Task\\Ext\\Analyzer\\Pdepend\\PhpDependTask",
       "sonar": "Phing\\Task\\Ext\\Analyzer\\Sonar\\SonarTask"


### PR DESCRIPTION
Completely remove references to `phpcpd` and `phploc`, else phing will fail after a composer update.