### PR TITLE
Prevent a PHP 8.3 deprecation notice

### DIFF
--- a/classes/phing/Phing.php
+++ b/classes/phing/Phing.php
@@ -161,6 +161,9 @@ class Phing
     /** Whether or not output to the log is to be unadorned. */
     private $emacsMode = false;
 
+    /** @var ?string */
+    private $searchForThis = null;
+
     /**
      * Entry point allowing for more options from other front ends.
      *


### PR DESCRIPTION
This prevents PHP 8.3 from complaining about a runtime-created property:

`PHP Deprecated:  Creation of dynamic property Phing::$searchForThis is deprecated`
