### PR TITLE
(tasks/ext/git): Trim command output in setProperty

### DIFF
--- a/classes/phing/tasks/ext/git/GitLogTask.php
+++ b/classes/phing/tasks/ext/git/GitLogTask.php
@@ -143,7 +143,7 @@ class GitLogTask extends GitBaseTask
         }
 
         if (null !== $this->outputProperty) {
-            $this->project->setProperty($this->outputProperty, $output);
+            $this->project->setProperty($this->outputProperty, trim($output));
         }
 
         $this->log(

--- a/classes/phing/tasks/ext/git/GitTagTask.php
+++ b/classes/phing/tasks/ext/git/GitTagTask.php
@@ -204,7 +204,7 @@ class GitTagTask extends GitBaseTask
         }
 
         if (null !== $this->outputProperty) {
-            $this->project->setProperty($this->outputProperty, $output);
+            $this->project->setProperty($this->outputProperty, trim($output));
         }
 
         $this->log(


### PR DESCRIPTION
Fix missing trimming of EOL from command output in `setProperty`.