### PR TITLE
Fix(php-cs-fixer.dist.php): Use absolute paths from __DIR__

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,8 +1,8 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in('src/Phing')
-    ->in('tests/Phing')
+    ->in(__DIR__ . '/src/Phing')
+    ->in(__DIR__ . '/tests/Phing')
 ;
 
 $config = new PhpCsFixer\Config();


### PR DESCRIPTION
Allows php-cs-fixer's finder to resolve `src/Phing` and `tests/Phing` with full absolute paths, so it works regardless of current directory (like when invoked from an IDE plug-in for a single file. Ex: VS-Code)