### PR TITLE
add support for sebastian/version 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
-        "sebastian/version": "^3.0|^4.0",
+        "sebastian/version": "^3.0|^4.0|^5.0",
         "symfony/console": "^5.3.10|^6.0|^7.0",
         "symfony/yaml": "^5.0|^6.0|^7.0"
     },


### PR DESCRIPTION
We are updating our dependencies in Shopsys Platform and PHPUnit 11 now requires sebastian/version in version 5, so this is a needed change so we can make this update, thank you.