### PR TITLE
Allow new version of sebastian/version for phpunit 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
-        "sebastian/version": "^3.0|^4.0",
+        "sebastian/version": "^3.0|^4.0|^5.0",
         "symfony/console": "^5.3.10|^6.0|^7.0",
         "symfony/yaml": "^5.0|^6.0|^7.0"
     },


### PR DESCRIPTION
This PR recreates PR #1831 which I mistakenly closed thinking it to be obsolete. If accepted, this PR updates the allowed versions of the dependency `sebastian/version` allowing `phing` to be used in projects which wish to use phpunit version 11.x for testing.

Note because `phing `uses `phpunit` version 9 for unit testing which depends on `sebastian/version` version 3.x running unit tests alone is not a sufficient test of this dependency change. Instead a project needs to be created using `phing` and `phpunit` (at version 11) and the `build.xml` needs to include a target which invokes `Phing::getPhingVersion`. I've tried this in a closed source project but can come up with a stripped down example if desired.
