### PR TITLE
[ReplaceRegexpTask] Added failOnError support

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -5956,6 +5956,9 @@
                     <attribute name="replace"/>
                     <attribute name="flags"/>
                     <attribute name="byLine"/>
+                    <attribute name="failonerror" a:defaultValue="false">
+                        <data type="boolean"/>
+                    </attribute>
                 </optional>
             </interleave>
         </element>

--- a/src/Phing/Task/System/ReplaceRegexpTask.php
+++ b/src/Phing/Task/System/ReplaceRegexpTask.php
@@ -65,6 +65,15 @@ class ReplaceRegexpTask extends Task
      */
     private $regexp;
 
+    private $failonerror = false;
+
+    /**
+     * If false, note errors but continue.
+     */
+    public void setFailOnError($failonerror) {
+        $this->failonerror = $failonerror;
+    }
+
     /**
      * File to apply regexp on.
      */
@@ -201,6 +210,9 @@ class ReplaceRegexpTask extends Task
                     $in->close();
                 }
                 $this->log('Error reading file: ' . $e->getMessage(), Project::MSG_WARN);
+                if ($this->failonerror) {
+                    throw new BuildException("Error reading file: '" . $file->getAbsolutePath() . "'", $e);
+                }
             }
 
             try {
@@ -214,6 +226,9 @@ class ReplaceRegexpTask extends Task
                     $out->close();
                 }
                 $this->log('Error writing file back: ' . $e->getMessage(), Project::MSG_WARN);
+                if ($this->failonerror) {
+                    throw new BuildException("Error writing file back: '" . $file->getAbsolutePath() . "'", $e);
+                }
             }
         }
     }

--- a/src/Phing/Task/System/ReplaceRegexpTask.php
+++ b/src/Phing/Task/System/ReplaceRegexpTask.php
@@ -210,7 +210,7 @@ class ReplaceRegexpTask extends Task
                 if ($in) {
                     $in->close();
                 }
-                $this->log('Error reading file: ' . $e->getMessage(), Project::MSG_WARN);
+                $this->log('Error reading file: ' . $e->getMessage(), Project::MSG_ERR);
                 if ($this->failonerror) {
                     throw new BuildException("Error reading file: '" . $file->getAbsolutePath() . "'", $e);
                 }
@@ -226,7 +226,7 @@ class ReplaceRegexpTask extends Task
                 if ($out) {
                     $out->close();
                 }
-                $this->log('Error writing file back: ' . $e->getMessage(), Project::MSG_WARN);
+                $this->log('Error writing file back: ' . $e->getMessage(), Project::MSG_ERR);
                 if ($this->failonerror) {
                     throw new BuildException("Error writing file back: '" . $file->getAbsolutePath() . "'", $e);
                 }

--- a/src/Phing/Task/System/ReplaceRegexpTask.php
+++ b/src/Phing/Task/System/ReplaceRegexpTask.php
@@ -70,7 +70,8 @@ class ReplaceRegexpTask extends Task
     /**
      * If false, note errors but continue.
      */
-    public void setFailOnError($failonerror) {
+    public function setFailOnError($failonerror)
+    {
         $this->failonerror = $failonerror;
     }
 

--- a/tests/Phing/Test/Task/System/ReplaceRegexpTaskTest.php
+++ b/tests/Phing/Test/Task/System/ReplaceRegexpTaskTest.php
@@ -50,4 +50,13 @@ class ReplaceRegexpTaskTest extends BuildFileTest
         $this->executeTarget(__FUNCTION__);
         $this->assertStringEqualsFile('test.properties', 'NewProperty=12345');
     }
+
+    public function testFailOnError(): void
+    {
+        $this->expectSpecificBuildException(
+            __FUNCTION__,
+            'failonerror has to fail',
+            "Error reading file: 'filesetwillmostlikelyneversupportthisattribute'"
+        );
+    }
 }

--- a/tests/Phing/Test/Task/System/ReplaceRegexpTaskTest.php
+++ b/tests/Phing/Test/Task/System/ReplaceRegexpTaskTest.php
@@ -53,10 +53,10 @@ class ReplaceRegexpTaskTest extends BuildFileTest
 
     public function testFailOnError(): void
     {
-        $this->expectSpecificBuildException(
+        $this->expectBuildExceptionContaining(
             __FUNCTION__,
             'failonerror has to fail',
-            "Error reading file: 'filesetwillmostlikelyneversupportthisattribute'"
+            "Error reading file:"
         );
     }
 }

--- a/tests/etc/tasks/system/ReplaceRegexpTaskTest.xml
+++ b/tests/etc/tasks/system/ReplaceRegexpTaskTest.xml
@@ -11,4 +11,10 @@
              match="OldProperty=(.*)"
              replace="NewProperty=\1"/>
     </target>
+    <target name="testFailOnError">
+        <replaceregexp file="nofile"
+             match="OldProperty=(.*)"
+             replace="NewProperty=\1"
+             failonerror="true"/>
+    </target>
 </project>


### PR DESCRIPTION
`ReplaceRegexpTask` does not support a `failOnError` and just log them as a warning.

* Added `failOnError` attribute with default `false`
* Changed loglevel from warning to error
