### PR TITLE
Introduce DisguiseLogger

### DIFF
--- a/src/Phing/Listener/DisguiseLogger.php
+++ b/src/Phing/Listener/DisguiseLogger.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information please see
+ * <http://phing.info>.
+ */
+
+namespace Phing\Listener;
+
+use Phing\Phing;
+
+/**
+ * @author  Siad Ardroumli <siad.ardroumli@gmail.com>
+ */
+class DisguiseLogger extends DefaultLogger
+{
+    public function messageLogged(BuildEvent $event)
+    {
+        $this->maskUriPassword($event);
+        parent::messageLogged($event);
+    }
+
+    public function buildStarted(BuildEvent $event) {}
+
+    public function buildFinished(BuildEvent $event) {}
+
+    public function targetStarted(BuildEvent $event) {}
+
+    public function targetFinished(BuildEvent $event) {}
+
+    public function taskStarted(BuildEvent $event) {}
+
+    public function taskFinished(BuildEvent $event) {}
+
+    protected function maskUriPassword(BuildEvent $event): void
+    {
+        $event->setMessage(
+            preg_replace(
+                '!://(.*):(.*)@!',
+                '://$1:*****@',
+                $event->getMessage()
+            ),
+            $event->getPriority()
+        );
+    }
+}

--- a/src/Phing/Listener/DisguiseLogger.php
+++ b/src/Phing/Listener/DisguiseLogger.php
@@ -33,17 +33,29 @@ class DisguiseLogger extends DefaultLogger
         parent::messageLogged($event);
     }
 
-    public function buildStarted(BuildEvent $event) {}
+    public function buildStarted(BuildEvent $event)
+    {
+    }
 
-    public function buildFinished(BuildEvent $event) {}
+    public function buildFinished(BuildEvent $event)
+    {
+    }
 
-    public function targetStarted(BuildEvent $event) {}
+    public function targetStarted(BuildEvent $event)
+    {
+    }
 
-    public function targetFinished(BuildEvent $event) {}
+    public function targetFinished(BuildEvent $event)
+    {
+    }
 
-    public function taskStarted(BuildEvent $event) {}
+    public function taskStarted(BuildEvent $event)
+    {
+    }
 
-    public function taskFinished(BuildEvent $event) {}
+    public function taskFinished(BuildEvent $event)
+    {
+    }
 
     protected function maskUriPassword(BuildEvent $event): void
     {

--- a/tests/Phing/Test/Listener/DisguiseLoggerTest.php
+++ b/tests/Phing/Test/Listener/DisguiseLoggerTest.php
@@ -28,4 +28,64 @@ class DisguiseLoggerTest extends TestCase
         $event->setMessage('https://foo:bar@example.com', $event->getPriority());
         $this->assertNull($this->logger->messageLogged($event));
     }
+
+    /**
+     * @test
+     */
+    public function buildStarted()
+    {
+        $event = new BuildEvent(new Project());
+        $event->setMessage('https://foo:bar@example.com', $event->getPriority());
+        $this->assertNull($this->logger->buildStarted($event));
+    }
+
+    /**
+     * @test
+     */
+    public function buildFinished()
+    {
+        $event = new BuildEvent(new Project());
+        $event->setMessage('https://foo:bar@example.com', $event->getPriority());
+        $this->assertNull($this->logger->buildFinished($event));
+    }
+
+    /**
+     * @test
+     */
+    public function targetStarted()
+    {
+        $event = new BuildEvent(new Project());
+        $event->setMessage('https://foo:bar@example.com', $event->getPriority());
+        $this->assertNull($this->logger->targetStarted($event));
+    }
+
+    /**
+     * @test
+     */
+    public function targetFinished()
+    {
+        $event = new BuildEvent(new Project());
+        $event->setMessage('https://foo:bar@example.com', $event->getPriority());
+        $this->assertNull($this->logger->targetFinished($event));
+    }
+
+    /**
+     * @test
+     */
+    public function taskStarted()
+    {
+        $event = new BuildEvent(new Project());
+        $event->setMessage('https://foo:bar@example.com', $event->getPriority());
+        $this->assertNull($this->logger->taskStarted($event));
+    }
+
+    /**
+     * @test
+     */
+    public function taskFinished()
+    {
+        $event = new BuildEvent(new Project());
+        $event->setMessage('https://foo:bar@example.com', $event->getPriority());
+        $this->assertNull($this->logger->taskFinished($event));
+    }
 }

--- a/tests/Phing/Test/Listener/DisguiseLoggerTest.php
+++ b/tests/Phing/Test/Listener/DisguiseLoggerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phing\Test\Listener;
+
+use Phing\Listener\BuildEvent;
+use Phing\Listener\DisguiseLogger;
+use Phing\Project;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class DisguiseLoggerTest extends TestCase
+{
+    private DisguiseLogger $logger;
+
+    public function setUp(): void
+    {
+        $this->logger = new DisguiseLogger();
+    }
+
+    /**
+     * @test
+     */
+    public function maskOutput()
+    {
+        $event = new BuildEvent(new Project());
+        $event->setMessage('https://foo:bar@example.com', $event->getPriority());
+        $this->assertNull($this->logger->messageLogged($event));
+    }
+}


### PR DESCRIPTION
Related to #1672 

* Added `DisguiseLogger`

Using this logger prevents output logging for passwords in URIs and mask them with `*****`

**build.xml**
```
<project name="Test" default="test" basedir=".">
    <target name="test">
        <echo msg="some text and a link to http://foo:bar@example.com/baz?one=two" />
    </target>
</project>
```

**using logger**
```
phing -logger "Phing\Listener\DisguiseLogger" -f build.xml
```

**output**
```
     [echo] some text and a link to http://foo:*****@example.com/baz?one=two
```