### PR TITLE
Fixed failing dependabot workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
 
   build_docker_image:
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'phingofficial' && github.event_name != 'pull_request' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'phingofficial' && github.event_name != 'pull_request' }}
     needs:
       - test
     steps:


### PR DESCRIPTION
See for reference: https://github.com/phingofficial/phing/actions/runs/12104908943/job/33749537007

Added condition to ignore the dependabot actor for the docker build image step.