### PR TITLE
 phing-grammar.rng: Fix optional attributes in different tasks

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -1724,19 +1724,19 @@
 
     <define name="echoxml">
         <element name="echoxml">
-            <choice>
-                <interleave>
+            <interleave>
+                <optional>
+                    <attribute name="file"/>
                     <optional>
-                        <attribute name="file"/>
                         <attribute name="append" >
                             <data type="boolean" a:defaultValue="false"/>
                         </attribute>
                     </optional>
-                </interleave>
-                <zeroOrMore>
-                    <ref name="any_element" />
-                </zeroOrMore>
-            </choice>
+                </optional>                
+            </interleave>
+            <zeroOrMore>
+                <ref name="any_element" />
+            </zeroOrMore>
         </element>
     </define>
 

--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -2899,6 +2899,8 @@
           <attribute name="command">
             <data type="string"/>
           </attribute>
+        </optional>
+        <optional>
           <attribute name="php">
             <data type="string"/>
           </attribute>


### PR DESCRIPTION
Previous definition did not capture how echoxml is working and documented:
Wrong was:
- If file or append attribute is supplied, the other one would be enforced
- If file or append is supplied, children are forbidden. Due to choice element attribute and children are mutually exclusive. 

Imho correct is: 
- file is optional
- append is optional - though makes no sense if no file attribute is supplied 
- any children can exist - no matter the variation of attributes