### PR TITLE
Fix Grammar: composerTask attributes are each optional

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -2899,6 +2899,8 @@
           <attribute name="command">
             <data type="string"/>
           </attribute>
+        </optional>
+        <optional>
           <attribute name="php">
             <data type="string"/>
           </attribute>


### PR DESCRIPTION
According to docu https://www.phing.info/guide/hlhtml/#ComposerTask composer and php attributes are optional, with default behaviour if they are omitted. It works to use one of them.
The old version of the grammar did not allow only one of them - only none or both. With this fix both, none or one of them are allowed and correctly validated