### PR TITLE
Fix echoxml definition in phing-grammar.rng

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -1724,19 +1724,19 @@
 
     <define name="echoxml">
         <element name="echoxml">
-            <choice>
-                <interleave>
+            <interleave>
+                <optional>
+                    <attribute name="file"/>
                     <optional>
-                        <attribute name="file"/>
                         <attribute name="append" >
                             <data type="boolean" a:defaultValue="false"/>
                         </attribute>
                     </optional>
-                </interleave>
-                <zeroOrMore>
-                    <ref name="any_element" />
-                </zeroOrMore>
-            </choice>
+                </optional>                
+            </interleave>
+            <zeroOrMore>
+                <ref name="any_element" />
+            </zeroOrMore>
         </element>
     </define>
 


### PR DESCRIPTION
Previous definition did not capture how echoxml is working and documented: If file attribute is supplied, append would be enforced If file or append is supplied, children are forbidden. Due to choice element attribute and children are mutually exclusive.

Correct is:
file is optional
append is optional - though makes no sense if no file attribute is supplied any children can exist - no matter the variation of attributes
