### PR TITLE
Fix Grammar for Fileset element: selector element made optional and selectors added

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -861,8 +861,11 @@
                         </choice>
                     </attribute>
                 </optional>
+                <optional>
+                    <ref name="selector"/>
+                </optional>
+                <ref name="selectors"/>
             </interleave>
-            <ref name="selector"/>
         </element>
     </define>
 


### PR DESCRIPTION
Moved element into interleave and made optional

selector**s** are allowed in fileset: Added
Selector Element is not part of selector**s**!