### PR TITLE
Fix Grammar for delete

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -1600,8 +1600,10 @@
                 </optional>
             </interleave>
             <zeroOrMore>
-                <ref name="dirset"/>
-                <ref name="fileset"/>
+                <choice>
+                    <ref name="dirset"/>
+                    <ref name="fileset"/>
+                </choice>
             </zeroOrMore>
         </element>
     </define>


### PR DESCRIPTION
fixed delete: It may contain any number of dirset and fileset. Old implementation forced the to be present as pair