### PR TITLE
Fix Grammar for fail element

### DIFF
--- a/etc/phing-grammar.rng
+++ b/etc/phing-grammar.rng
@@ -1870,7 +1870,11 @@
                         <attribute name="message"/>
                         <attribute name="msg"/>
                     </choice>
+                </optional>
+                <optional>
                     <attribute name="if"/>
+                </optional>
+                <optional>
                     <attribute name="unless"/>
                 </optional>
             </interleave>


### PR DESCRIPTION
fixed: msg/message, if or unless can be used without the other. Old implementation forced all threee to be present