### PR TITLE
Fix option help message of `-inputhandler`

### DIFF
--- a/src/Phing/Phing.php
+++ b/src/Phing/Phing.php
@@ -561,29 +561,29 @@ class Phing
         $msg = <<<'TEXT'
             phing [options] [target [target2 [target3] ...]]
             Options:
-              -h -help                 print this message
-              -l -list                 list available targets in this project
-              -i -init [file]          generates an initial buildfile
-              -v -version              print the version information and exit
-              -q -quiet                be extra quiet
-              -S -silent               print nothing but task outputs and build failures
-                 -verbose              be extra verbose
-                 -debug                print debugging information
-              -e -emacs                produce logging information without adornments
-                 -diagnostics          print diagnostics information
-                 -strict               runs build in strict mode, considering a warning as error
-                 -no-strict            runs build normally (overrides buildfile attribute)
-                 -longtargets          show target descriptions during build
-                 -logfile <file>       use given file for log
-                 -logger <classname>   the class which is to perform logging
-                 -listener <classname> add an instance of class as a project listener
-              -f -buildfile <file>     use given buildfile
-                 -D<property>=<value>  use value for given property
-              -k -keep-going           execute all targets that do not depend on failed target(s)
-                 -propertyfile <file>  load all properties from file
-                 -propertyfileoverride values in property file override existing values
-                 -find <file>          search for buildfile towards the root of the filesystem and use it
-                 -inputhandler <file>  the class to use to handle user input
+              -h -help                     print this message
+              -l -list                     list available targets in this project
+              -i -init [file]              generates an initial buildfile
+              -v -version                  print the version information and exit
+              -q -quiet                    be extra quiet
+              -S -silent                   print nothing but task outputs and build failures
+                 -verbose                  be extra verbose
+                 -debug                    print debugging information
+              -e -emacs                    produce logging information without adornments
+                 -diagnostics              print diagnostics information
+                 -strict                   runs build in strict mode, considering a warning as error
+                 -no-strict                runs build normally (overrides buildfile attribute)
+                 -longtargets              show target descriptions during build
+                 -logfile <file>           use given file for log
+                 -logger <classname>       the class which is to perform logging
+                 -listener <classname>     add an instance of class as a project listener
+              -f -buildfile <file>         use given buildfile
+                 -D<property>=<value>      use value for given property
+              -k -keep-going               execute all targets that do not depend on failed target(s)
+                 -propertyfile <file>      load all properties from file
+                 -propertyfileoverride     values in property file override existing values
+                 -find <file>              search for buildfile towards the root of the filesystem and use it
+                 -inputhandler <classname> the class to use to handle user input
 
             Report bugs to https://github.com/phingofficial/phing/issues
 


### PR DESCRIPTION
`-inputhandler` flag should take a class name, not a file.