### PR TITLE
Removing unnecessary xdg-open 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,6 @@ jobs:
       - name: Static analysis (level 1)
         run: vendor/bin/phpstan --ansi --no-progress --no-interaction
 
-      - name: 'Install fake xdg-open (required by OpenTaskTest.php)'
-        run : ln -s /usr/bin/true /usr/bin/xdg-open
-
   test:
     needs:
       - pre_job


### PR DESCRIPTION
~The default use of `xdg-open` forces installation of the `xdg-utils` package, since there's is no desktop environment in CI, it has no sense to use `xdg-open`.~

~In this PR I replace `xdg-open` with a symlink of `/usr/bin/true` (which always returns 0), this should speed up a little bit the pipelines since `xdg-utils` is not installed anymore.~

Well, at the end "xdg-open" is not required in "static_code_analysis" step. 

Aditionally, I had already set a "fake xdg-open" some lines below in the same file:

https://github.com/phingofficial/phing/blob/7d28dac37142d77aae99268fb18990aa404bd7fc/.github/workflows/build.yml#L98-L101

